### PR TITLE
docs: add MkDocs site, GitHub Pages workflow, and polish README

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,54 @@
+name: Docs
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'requirements-docs.txt'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: pip install -r requirements-docs.txt
+
+      - name: Build docs
+        run: mkdocs build --strict
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ vite.svg
 uv.lock
 tsconfig.tsbuildinfo
 apps/web/tsconfig.tsbuildinfo
+site/
+
+# Sisyphus agent state
+.sisyphus/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Azure Atlas
 
 ![CI](https://github.com/yeongseon/azure-atlas/actions/workflows/ci.yml/badge.svg)
+[![Docs](https://github.com/yeongseon/azure-atlas/actions/workflows/docs.yml/badge.svg)](https://yeongseon.github.io/azure-atlas)
 
 > Explore Azure as a knowledge map.
 
@@ -93,6 +94,10 @@ pnpm typecheck  # Typecheck web app
   - **Compute** (48 nodes, VM-centric) — Virtual Machine, VMSS, Availability Sets/Zones, Trusted Launch, Disk Encryption, Autoscale, Backup, Site Recovery, and more
 - **Views**: Concept Graph + Evidence Panel + Search
 - **Journeys**: 25 curated scenarios across 3 domains
+
+## Documentation
+
+Full documentation is available at **[yeongseon.github.io/azure-atlas](https://yeongseon.github.io/azure-atlas)**.
 
 ## Contributing
 

--- a/docs/architecture/api.md
+++ b/docs/architecture/api.md
@@ -1,0 +1,47 @@
+# API Reference
+
+Azure Atlas provides a robust, RESTful API for querying the ontology, searching nodes, and managing the curation queue.
+
+## Base URL
+
+All API requests are made to the following base URL:
+
+`/api/v1`
+
+## Endpoints
+
+| Method | Path | Description | Auth |
+| ------ | ---- | ----------- | ---- |
+| `GET` | `/health` | Health check for the API service. | Public |
+| `GET` | `/readyz` | Readiness check (validates DB + Redis). | Public |
+| `GET` | `/version` | Returns current system version information. | Public |
+| `GET` | `/meta` | Aggregate statistics for the ontology. | Public |
+| `GET` | `/api/v1/domains` | List all available ontology domains. | Public |
+| `GET` | `/api/v1/domains/{domain_id}` | Retrieve domain details and its subgraph. | Public |
+| `GET` | `/api/v1/nodes/{node_id}` | Retrieve a specific node's metadata. | Public |
+| `GET` | `/api/v1/nodes/{node_id}/subgraph` | Retrieve the subgraph centered on a node. | Public |
+| `GET` | `/api/v1/nodes/{node_id}/evidence` | Retrieve documentation evidence for a node. | Public |
+| `GET` | `/api/v1/search` | Full-text search across all nodes. | Public |
+| `GET` | `/api/v1/journeys` | List all available learning journeys. | Public |
+| `GET` | `/api/v1/journeys/{journey_id}` | Retrieve journey details and steps. | Public |
+| `POST` | `/api/v1/events` | Track an analytics event. | API Key |
+| `GET` | `/api/v1/curation/queue` | List pending curation items. | API Key |
+| `PATCH` | `/api/v1/curation/queue/{item_id}` | Submit a curation decision. | API Key |
+
+## Authentication
+
+Write operations and sensitive endpoints require an API key for authentication. This key must be provided in the `X-API-Key` header of each request.
+
+```http
+GET /api/v1/curation/queue HTTP/1.1
+X-API-Key: your_secret_api_key
+```
+
+## Interactive Documentation
+
+Azure Atlas includes a built-in Swagger UI for interactive API exploration. You can access it at the following URL:
+
+[http://localhost:8001/docs](http://localhost:8001/docs)
+
+!!! tip "Query Parameters"
+    The `/api/v1/nodes/{node_id}/subgraph` endpoint accepts `depth` and `relation_types` parameters to customize the scope of the returned graph.

--- a/docs/architecture/database.md
+++ b/docs/architecture/database.md
@@ -1,0 +1,50 @@
+# Database Schema
+
+Azure Atlas uses a customized PostgreSQL 16 database to store the ontology. It features a normalized schema optimized for graph traversals and full-text search.
+
+## Entity-Relationship Diagram
+
+The following diagram illustrates the key tables and their relationships within the ontology:
+
+```mermaid
+erDiagram
+    DOMAINS ||--o{ NODES : contains
+    NODES ||--o{ EDGES : connects
+    NODES ||--o{ NODE_EVIDENCE : has
+    EDGES ||--o{ EDGE_EVIDENCE : has
+    EVIDENCE ||--o{ NODE_EVIDENCE : provides
+    EVIDENCE ||--o{ EDGE_EVIDENCE : provides
+    JOURNEYS ||--o{ JOURNEY_STEPS : contains
+    NODES ||--o{ JOURNEY_STEPS : targets
+    CURATION_QUEUE ||--o{ NODES : proposes
+    PROVENANCE ||--o{ NODES : tracks
+```
+
+## Key Tables
+
+-   **`domains`**: High-level categories (e.g., Network, Storage, Compute).
+-   **`nodes`**: The fundamental entities in the ontology (e.g., Virtual Network, Azure Storage).
+-   **`edges`**: Relationships between nodes (e.g., `Virtual Network` -> `contains` -> `Subnet`).
+-   **`evidence`**: Snippets and links to official Microsoft documentation.
+-   **`journeys`**: Curated learning paths through the ontology.
+-   **`curation_queue`**: Pending changes to the ontology awaiting approval.
+-   **`analytics_events`**: User interaction and system tracking events.
+
+## Design Decisions
+
+Azure Atlas incorporates several specific design choices to ensure data integrity and query efficiency:
+
+-   **Text Primary Keys:** Nodes and domains use human-readable text slugs as primary keys (e.g., `azure-vnet`, `networking`). This makes URLs and queries more intuitive.
+-   **UUID PKs:** Edges, evidence, and journey steps use UUIDs for primary keys to support distributed generation and avoid sequence collisions.
+-   **Full-Text Search (FTS):** Generated `tsvector` columns are used for high-performance searching across node names and descriptions.
+-   **Cycle Prevention:** A database-level trigger on the `edges` table prevents circular dependencies in hierarchical relationships.
+-   **Status Workflow:** A `content_status_enum` tracks the lifecycle of nodes and edges from `draft` to `approved`.
+
+## Migration and Seeding
+
+The database schema is managed via migration scripts located in `apps/api/migrations/`. 
+
+Ontology content is applied using seed files in `packages/ontology/seed_*.sql`. These seeds are idempotent and can be re-run safely without duplicating data.
+
+!!! tip "Custom Types"
+    Azure Atlas uses custom PostgreSQL enums for `node_type` and `relation_type` to enforce strict data modeling at the database level.

--- a/docs/architecture/frontend.md
+++ b/docs/architecture/frontend.md
@@ -1,0 +1,44 @@
+# Frontend Architecture
+
+Azure Atlas features a reactive, single-page application (SPA) built with React 18, Vite, and TypeScript. It is designed for interactive exploration of the Azure ontology.
+
+## Tech Stack
+
+The following tools are used to build the frontend:
+
+-   **React 18:** Functional components and hooks for building the UI.
+-   **Vite:** A fast, modern build tool and development server.
+-   **TypeScript:** Static typing for all components and data structures.
+-   **React Flow (@xyflow/react):** The core library for rendering the interactive graph.
+-   **TanStack Query:** Server-state management and asynchronous data fetching.
+
+## Route Architecture
+
+The frontend uses a client-side router with the following primary routes:
+
+| Route | Page Component | Description |
+| ----- | -------------- | ----------- |
+| `/` | `WorldMapPage` | The main landing page listing all domains and learning journeys. |
+| `/domains/:domainId` | `ConceptGraphPage` | An interactive graph view for a specific domain. |
+| `/nodes/:nodeId` | `ConceptGraphPage` | A focused subgraph view centered on a specific node. |
+| `/search` | `SearchPage` | Full-text search interface with filters. |
+| `/journeys/:journeyId` | `JourneyPage` | A guided walkthrough of a specific learning journey. |
+
+## Graph Visualization
+
+The graph visualization is the heart of Azure Atlas. It is built using **React Flow** and incorporates several key features:
+
+-   **Dagre Layout:** Automatic hierarchical layout calculation for clear graph presentation.
+-   **Custom Nodes:** Specialized React components for rendering domain, service, and concept nodes.
+-   **Dark Theme:** A sleek, slate-based dark theme optimized for technical documentation.
+-   **Interactive Controls:** Zoom, pan, and mini-map for navigating complex graphs.
+
+## State Management
+
+Azure Atlas uses a clean separation between UI state and server state:
+
+-   **Server State:** Managed by **TanStack Query**. It handles caching, background fetching, and synchronization with the FastAPI backend.
+-   **UI State:** Managed by standard React hooks (`useState`, `useContext`). This includes current zoom levels, selected nodes, and search filters.
+
+!!! tip "Performance"
+    React Flow is highly optimized for performance, allowing Azure Atlas to render graphs with hundreds of nodes and edges without noticeable lag.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,0 +1,45 @@
+# Architecture Overview
+
+Azure Atlas is built as a modern, containerized monorepo. It features a high-performance Python backend and a reactive TypeScript frontend, all connected by a robust PostgreSQL-based ontology.
+
+## High-Level Architecture
+
+The following diagram illustrates the primary components and data flow:
+
+```mermaid
+graph LR
+    Browser["React SPA"] --> API["FastAPI"]
+    API --> DB["PostgreSQL 16"]
+    API --> Cache["Redis"]
+    Cache --> Worker["ARQ Worker"]
+```
+
+## Tech Stack
+
+| Layer | Technology |
+| ----- | ---------- |
+| **Frontend** | React 18, Vite, TypeScript, React Flow, TanStack Query |
+| **Backend** | FastAPI, asyncpg, Pydantic v2 |
+| **Database** | PostgreSQL 16 (with full-text search) |
+| **Caching/Queue** | Redis, ARQ |
+| **Infrastructure** | Podman, GitHub Actions |
+
+## Monorepo Structure
+
+The repository is organized into distinct packages and applications:
+
+-   `apps/api/`: The FastAPI backend server.
+-   `apps/web/`: The React frontend application.
+-   `packages/ontology/`: Shared ontology data, seed SQL files, and migration scripts.
+-   `docs/`: Project documentation (MkDocs).
+
+## Data Flow
+
+1.  **Request:** The React frontend makes an asynchronous request to the FastAPI backend using TanStack Query.
+2.  **Processing:** The backend validates the request using Pydantic models and executes queries against PostgreSQL using `asyncpg` for high performance.
+3.  **Caching:** Frequently accessed domain and node data are cached in Redis to reduce database load.
+4.  **Background Tasks:** Long-running operations like ontology indexing or document scraping are offloaded to an ARQ worker process.
+5.  **Response:** The processed data is returned to the frontend as a structured JSON response and rendered into the interactive graph.
+
+!!! tip "Performance Focus"
+    By using an asynchronous stack from top to bottom (React -> FastAPI -> asyncpg), Azure Atlas can handle complex graph queries with minimal latency.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,51 @@
+# Contributing
+
+Thank you for your interest in contributing to Azure Atlas. We welcome contributions of all types, from code improvements to ontology enhancements and documentation updates.
+
+## Getting Started
+
+1.  **Fork the Repository:** Start by forking the `yeongseon/azure-atlas` repository on GitHub.
+2.  **Clone Locally:** Clone your fork to your development machine.
+3.  **Setup Environment:** Follow the [Development Setup](development/setup.md) guide to get the project running locally.
+
+## Code Style
+
+Consistency is key to maintaining a high-quality codebase. We use several tools to enforce code style:
+
+### Python (API)
+-   **Ruff:** Used for linting and formatting.
+-   **Strict Typing:** All new functions and classes should have complete type hints.
+
+### TypeScript (Web)
+-   **ESLint:** Standard React and TypeScript linting rules.
+-   **Prettier:** Code formatting for all `.ts`, `.tsx`, and `.css` files.
+
+## Commit Convention
+
+We follow the **Conventional Commits** specification for all commit messages. This helps automate our release process and changelog generation.
+
+-   `feat:` A new feature.
+-   `fix:` A bug fix.
+-   `docs:` Documentation changes.
+-   `style:` Changes that do not affect the meaning of the code (white-space, formatting, etc).
+-   `refactor:` A code change that neither fixes a bug nor adds a feature.
+-   `test:` Adding missing tests or correcting existing tests.
+-   `chore:` Changes to the build process or auxiliary tools.
+
+## Pull Request Process
+
+1.  **Branch Naming:** Use descriptive branch names like `feat/add-new-domain` or `fix/graph-rendering`.
+2.  **Self-Review:** Before submitting, run `make lint` and `make test` locally to ensure everything is in order.
+3.  **Open PR:** Submit your pull request against the `main` branch of the original repository.
+4.  **Review:** Provide a clear description of your changes and wait for a maintainer to review your work.
+
+## Extending the Ontology
+
+Contributing to the ontology is one of the most impactful ways to help Azure Atlas.
+
+-   **Add Nodes:** Expand our coverage of Azure services and features.
+-   **Improve Evidence:** Add more accurate or recent documentation excerpts from MS Learn.
+-   **Curate Journeys:** Create new learning paths for complex architectural scenarios.
+
+!!! tip "Small PRs"
+    We prefer small, focused pull requests that are easy to review and merge quickly.

--- a/docs/development/ci-cd.md
+++ b/docs/development/ci-cd.md
@@ -1,0 +1,37 @@
+# CI/CD
+
+Azure Atlas uses **GitHub Actions** for its continuous integration (CI) and continuous delivery (CD) pipeline. This ensures that every change is thoroughly tested and documented before being merged into the main branch.
+
+## CI Pipeline Overview
+
+The CI pipeline is triggered on every push to the `main` branch and on every pull request. It consists of several parallel jobs:
+
+| Job | Description |
+| --- | ----------- |
+| `lint-api` | Runs **Ruff** for Python code style and formatting. |
+| `test-api` | Runs the **pytest** suite for the FastAPI backend. |
+| `lint-web` | Runs **ESLint** for React and TypeScript code style. |
+| `typecheck-web` | Runs **TypeScript** type-checking for the frontend application. |
+| `build-web` | Verifies that the React application can be built successfully. |
+
+## Deployment Pipeline
+
+The CD pipeline is responsible for deploying the latest version of Azure Atlas and its documentation.
+
+### GitHub Pages Deployment
+
+The documentation site is automatically built and deployed to **GitHub Pages** whenever changes are merged into the `main` branch.
+
+-   **Workflow File:** `.github/workflows/docs.yml`
+-   **Tool:** **MkDocs Material**
+-   **URL:** [https://yeongseon.github.io/azure-atlas](https://yeongseon.github.io/azure-atlas)
+
+### Application Deployment
+
+The application itself is deployed as a set of containerized services.
+
+-   **Development Branch:** Pushes to the `dev` branch are automatically deployed to our staging environment.
+-   **Main Branch:** Pushes to the `main` branch trigger a production deployment after a manual approval step.
+
+!!! tip "Release Tags"
+    Significant versions of Azure Atlas are tagged using semantic versioning (e.g., `v1.2.0`). This triggers an automated release process on GitHub.

--- a/docs/development/setup.md
+++ b/docs/development/setup.md
@@ -1,0 +1,72 @@
+# Development Setup
+
+Azure Atlas provides a flexible development environment that supports both bare-metal and containerized development.
+
+## Container-Based Development
+
+The recommended way to develop Azure Atlas is through **Podman**. This ensures that all developers are using the same versions of PostgreSQL, Redis, and other dependencies.
+
+1.  **Start Services:** Use the following command to spin up the full stack in the background:
+    ```bash
+    make up-dev
+    ```
+2.  **View Logs:** To see the logs from all running containers:
+    ```bash
+    make logs-dev
+    ```
+3.  **Stop Services:** To shut down the containers and free up resources:
+    ```bash
+    make down-dev
+    ```
+
+## Bare-Metal Development
+
+If you prefer to run the services directly on your host machine, follow these steps:
+
+### API Backend
+
+The backend is a FastAPI application that requires a running PostgreSQL instance.
+
+1.  Navigate to the API directory and install dependencies:
+    ```bash
+    cd apps/api
+    pip install -r requirements.txt
+    ```
+2.  Start the development server with live-reloading:
+    ```bash
+    uvicorn main:app --reload --port 8001
+    ```
+
+### Web Frontend
+
+The frontend is a Vite-based React application.
+
+1.  Navigate to the web directory and install dependencies:
+    ```bash
+    cd apps/web
+    pnpm install
+    ```
+2.  Start the Vite development server:
+    ```bash
+    pnpm dev
+    ```
+
+## Database Management
+
+Common database operations can be performed using the `make` utility:
+
+-   **Apply Migrations:** `make migrate`
+-   **Reset and Seed Database:** `make reset-db`
+-   **Schema Only:** `make schema`
+-   **Seed Only:** `make seed`
+
+## Workspace Scripts
+
+Azure Atlas uses a centralized workspace for common tasks:
+
+-   `pnpm build`: Build the web application for production.
+-   `pnpm lint`: Run linting for the web application.
+-   `pnpm typecheck`: Run TypeScript type-checking for the web application.
+
+!!! tip "Hybrid Mode"
+    You can run the database and Redis in containers (`make up-db`) while running the API and Web services locally for faster development cycles.

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -1,0 +1,52 @@
+# Testing
+
+Azure Atlas ensures quality through a comprehensive testing strategy that covers both the backend API and the frontend web application.
+
+## API Testing
+
+The FastAPI backend uses **pytest** for both unit and integration testing.
+
+1.  **Shared Fixtures:** Common database and Redis fixtures are shared across all tests to ensure consistency and speed.
+2.  **Running Tests:** Execute the following command from the root directory:
+    ```bash
+    make test-api
+    ```
+    Alternatively, run pytest directly from the `apps/api/` directory:
+    ```bash
+    cd apps/api
+    pytest tests/
+    ```
+
+## Web Testing
+
+The React frontend uses **TypeScript** and **ESLint** for static analysis and type safety.
+
+1.  **Type-Checking:** To ensure all TypeScript definitions are correct and consistent:
+    ```bash
+    make typecheck
+    ```
+2.  **Linting:** To verify code style and common patterns:
+    ```bash
+    make lint
+    ```
+3.  **Running Web Tests:** Execute the following command from the root directory:
+    ```bash
+    make test-web
+    ```
+
+## Smoke Tests
+
+Azure Atlas includes a specific **smoke test** suite to verify that all core services are running and connected properly.
+
+1.  **Run Smoke Tests:** Execute the following command:
+    ```bash
+    make smoke
+    ```
+2.  **Verification:** This command checks for the following:
+    -   API `/health` endpoint is reachable.
+    -   Database connection is active.
+    -   Redis connection is active.
+    -   Frontend dev server is running (optional).
+
+!!! tip "Continuous Integration"
+    All tests are automatically executed on every pull request via our GitHub Actions CI pipeline.

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -1,0 +1,38 @@
+# Configuration
+
+Azure Atlas uses environment variables for flexible configuration across development and production environments.
+
+## API Environment Variables
+
+The FastAPI backend is configured via a set of standard environment variables. You can find these in the `apps/api/.env` file.
+
+| Variable | Default Value | Description |
+| -------- | ------------- | ----------- |
+| `DATABASE_URL` | `postgresql://atlas:atlas@localhost:5432/atlas` | Connection string for PostgreSQL database. |
+| `REDIS_URL` | `redis://localhost:6379` | URL for the Redis server used by the ARQ worker. |
+| `LOG_LEVEL` | `info` | Logging verbosity (debug, info, warning, error). |
+| `ENVIRONMENT` | `development` | The environment the application is running in. |
+| `ALLOWED_ORIGINS` | `http://localhost:5173` | List of origins allowed for CORS. |
+| `API_KEY` | *(None)* | Secret key required for write endpoints. |
+
+!!! danger "Production Security"
+    In non-development environments, the `API_KEY` is mandatory. The application will fail to start if this variable is missing to prevent unauthorized write access to the ontology.
+
+## Web Environment Variables
+
+The React frontend configuration is located in the `apps/web/.env` file.
+
+| Variable | Description |
+| -------- | ----------- |
+| `VITE_API_URL` | The base URL for the FastAPI backend. Default: `http://localhost:8000/api/v1` |
+
+## Docker Compose Configuration
+
+Azure Atlas uses different Docker Compose files for development and production environments.
+
+-   **Base:** `docker-compose.yml` — shared service definitions (db, redis, api, web).
+-   **Development:** `docker-compose.dev.yml` — used by `make up-dev`. Mounts local directories for live-reloading.
+-   **Production:** `docker-compose.prod.yml` — builds immutable images with optimized settings and nginx reverse proxy.
+
+!!! tip "Container Runtime"
+    Azure Atlas uses Podman as the container runtime. All `make` targets invoke `podman-compose` instead of `docker-compose`.

--- a/docs/getting-started/prerequisites.md
+++ b/docs/getting-started/prerequisites.md
@@ -1,0 +1,71 @@
+# Prerequisites
+
+Before you begin setting up Azure Atlas, ensure your development environment meets the following requirements.
+
+## Core Dependencies
+
+Ensure these core tools are installed on your machine:
+
+-   **Podman** 4.5+ with **podman-compose** for containerized services.
+-   **Node.js** 20.x or later with **pnpm** for the React frontend.
+-   **Python** 3.12 or later for the FastAPI backend and management scripts.
+
+## Installation by Platform
+
+Follow the specific steps for your operating system to set up these dependencies.
+
+=== "macOS"
+
+    1.  Install **Homebrew** if not already present.
+    2.  Install Podman and Python:
+        ```bash
+        brew install podman podman-compose python@3.12
+        ```
+    3.  Initialize and start the Podman machine:
+        ```bash
+        podman machine init
+        podman machine start
+        ```
+    4.  Install Node.js and pnpm:
+        ```bash
+        brew install node
+        npm install -g pnpm
+        ```
+
+=== "Ubuntu"
+
+    1.  Update your package list and install Podman and Python:
+        ```bash
+        sudo apt update
+        sudo apt install podman podman-compose python3.12 python3.12-venv
+        ```
+    2.  Ensure Python 3.12 is the default or create a virtual environment:
+        ```bash
+        python3.12 -m venv .venv
+        source .venv/bin/activate
+        ```
+    3.  Install Node.js and pnpm:
+        ```bash
+        curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
+        sudo apt install -y nodejs
+        sudo npm install -g pnpm
+        ```
+
+=== "Windows WSL"
+
+    1.  Ensure you have **WSL 2** installed and configured (Ubuntu 22.04+ recommended).
+    2.  Within the WSL terminal, install Podman and Python:
+        ```bash
+        sudo apt update
+        sudo apt install podman podman-compose python3.12
+        ```
+    3.  Configure Podman to run in rootless mode.
+    4.  Install Node.js and pnpm:
+        ```bash
+        curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
+        sudo apt install -y nodejs
+        sudo npm install -g pnpm
+        ```
+
+!!! tip
+    On Windows, it is highly recommended to clone the repository within the WSL filesystem (e.g., `/home/username/repo`) rather than the Windows filesystem (`/mnt/c/...`) to avoid permission and performance issues.

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -1,0 +1,47 @@
+# Quickstart
+
+Get Azure Atlas up and running on your local machine with a single command.
+
+## One-Command Setup
+
+Azure Atlas provides a bootstrap script to automate environment setup, container orchestration, and database seeding.
+
+```bash
+make bootstrap
+```
+
+This command performs the following actions:
+1. Validates local prerequisites (Podman, Node.js, Python).
+2. Generates necessary `.env` files from templates.
+3. Builds and starts containers (PostgreSQL, Redis, API, Web).
+4. Runs database migrations and applies the ontology seed data.
+
+## Accessing the Application
+
+Once the bootstrap process completes, you can access the various components of the system:
+
+| Component | Environment | URL |
+| --------- | ----------- | --- |
+| **Web Frontend** | Development | [http://localhost:5173](http://localhost:5173) |
+| **API Backend** | Development | [http://localhost:8001/api/v1](http://localhost:8001/api/v1) |
+| **Interactive API Docs** | Development | [http://localhost:8001/docs](http://localhost:8001/docs) |
+
+## Common Commands
+
+Manage your development environment using these `make` commands:
+
+| Command | Description |
+| ------- | ----------- |
+| `make up-dev` | Start all dev services in the background. |
+| `make down-dev` | Stop and remove all dev containers. |
+| `make logs-dev` | Stream logs from all running dev services. |
+| `make reset-db` | Wipe the database and re-apply seeds. |
+| `make test-api` | Run the API test suite. |
+| `make test-web` | Typecheck and lint the web app. |
+| `make lint` | Lint both API and web. |
+
+!!! tip
+    If you encounter issues during the initial build, try `make down-dev` followed by `make bootstrap` to ensure a clean slate.
+
+!!! warning "Hardware Resources"
+    Running the full stack via Podman requires at least 4GB of RAM allocated to your container runtime.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,50 @@
+# Azure Atlas
+
+**Explore Azure as a knowledge map — ontology-based navigation for MS Learn.**
+
+Azure Atlas transforms fragmented documentation into a structured, interconnected graph. It allows users to navigate the Azure ecosystem through conceptual relationships, moving from high-level domains down to specific service mechanisms and features.
+
+---
+
+<div class="grid cards" markdown>
+
+-   :material-graph: __Ontology-Driven__
+    
+    Built on a robust ontology mapping Azure services, concepts, and relationships derived from official MS Learn documentation.
+
+-   :material-map-search: __Interactive Exploration__
+    
+    Visualize complex service dependencies and architectural patterns through dynamic graph visualizations powered by React Flow.
+
+-   :material-database-eye: __Evidence-Backed__
+    
+    Every node and relationship in the map is backed by excerpts and direct links to official Microsoft documentation.
+
+-   :material-map-marker-path: __Curated Journeys__
+    
+    Follow step-by-step learning paths for common scenarios, from basic networking to complex VM deployments.
+
+</div>
+
+---
+
+## Quick Navigation
+
+<div class="grid cards" markdown>
+
+-   [:material-rocket-launch: **Getting Started**](getting-started/quickstart.md)
+    
+    Set up Azure Atlas locally in minutes using our bootstrap scripts and containerized environment.
+
+-   [:material-office-building: **Architecture**](architecture/overview.md)
+    
+    Deep dive into the FastAPI backend, PostgreSQL schema, and React frontend architecture.
+
+-   [:material-account-group: **Contributing**](contributing.md)
+    
+    Learn how to add new domains, improve the ontology, or contribute to the codebase.
+
+</div>
+
+!!! tip "FastAPI Powered"
+    Azure Atlas uses a high-performance FastAPI backend with an asynchronous PostgreSQL driver for lightning-fast graph traversals.

--- a/docs/ontology/domains.md
+++ b/docs/ontology/domains.md
@@ -1,0 +1,45 @@
+# Domains
+
+Azure Atlas is organized into high-level domains, each representing a core area of the Microsoft Azure ecosystem. Currently, the ontology includes three comprehensive domains.
+
+## Domain Overview
+
+Each domain consists of a structured hierarchy of nodes, ranging from fundamental concepts to specific service features and mechanisms.
+
+### 1. Network Domain (43 nodes)
+
+The Network domain covers the foundational connectivity and security services in Azure. It models the relationships between virtual networks, subnets, and traffic control mechanisms.
+
+-   **Key Services:** Azure Virtual Network, Azure Load Balancer, Azure DNS, NSGs.
+-   **Core Concepts:** Hub-and-Spoke topology, VNet Peering, Private Link, Service Endpoints.
+-   **Relationships:** Connectivity (`connects_to`), routing (`routes_to`), and security (`secures`).
+
+### 2. Storage Domain (46 nodes)
+
+The Storage domain explores the various data persistence and management services available in Azure. It focuses on scalability, redundancy, and access patterns.
+
+-   **Key Services:** Blob Storage, Azure Files, Queue Storage, Table Storage.
+-   **Core Concepts:** Storage Tiers (Hot/Cool/Archive), Redundancy (LRS/GRS/ZRS), Soft Delete, Lifecycle Management.
+-   **Relationships:** Data flow (`contains`), replication (`depends_on`), and access control (`secures`).
+
+### 3. Compute Domain (48 nodes)
+
+The Compute domain centers on Virtual Machines and their associated infrastructure. It provides a detailed map of how VMs are provisioned, managed, and connected.
+
+-   **Key Services:** Azure Virtual Machines, VM Scale Sets, Disk Storage, Network Interfaces.
+-   **Core Concepts:** Availability Sets, Proximity Placement Groups, VM Extensions, OS Images.
+-   **Relationships:** Attachment (`attached_to`), provisioning (`depends_on`), and configuration (`contains`).
+
+## Statistics Table
+
+The following table provides a breakdown of the ontology's current scope:
+
+| Domain | Nodes | Edges | Evidence | Journeys |
+| ------ | ----- | ----- | -------- | -------- |
+| **Network** | 43 | 94 | 172 | 9 |
+| **Storage** | 46 | 81 | 184 | 8 |
+| **Compute** | 48 | 84 | 192 | 8 |
+| **Total** | **137** | **259** | **548** | **25** |
+
+!!! tip "Dynamic Updates"
+    Statistics are updated automatically as new seed files are applied or when the ontology is extended via the curation API.

--- a/docs/ontology/overview.md
+++ b/docs/ontology/overview.md
@@ -1,0 +1,51 @@
+# Ontology Overview
+
+The Azure Atlas ontology is a structured knowledge map of Microsoft Azure services, concepts, and relationships. It is derived from official MS Learn documentation and provides a clear mental model for understanding the Azure ecosystem.
+
+## Node Types
+
+Nodes represent the fundamental entities within the ontology. Each node is classified by its role and level of abstraction:
+
+| Node Type | Description | Example |
+| --------- | ----------- | ------- |
+| **domain** | High-level logical categories. | Network, Storage, Compute. |
+| **service** | Discrete Azure service offerings. | Azure VNet, Blob Storage, Azure VM. |
+| **concept** | Abstract architectural patterns or principles. | Hub and Spoke, Tiered Storage. |
+| **feature** | Specific capabilities within a service. | VNet Peering, Lifecycle Management. |
+| **resource** | Fundamental building blocks of services. | Subnet, NIC, NSG. |
+| **mechanism** | How a specific task is accomplished. | Default Routing, Soft Delete. |
+| **task** | Common user objectives or operations. | Create a VNet, Provision a VM. |
+| **problem** | Common architectural challenges. | Network Latency, Data Redundancy. |
+| **journey** | Curated step-by-step learning paths. | Zero-Trust Networking. |
+
+## Relation Types
+
+Edges define the relationships between nodes. Azure Atlas uses a rich set of relation types to model dependencies and interactions:
+
+-   `belongs_to`: Part-whole hierarchy (e.g., Subnet belongs to VNet).
+-   `contains`: Container-content relationship (e.g., Domain contains Services).
+-   `attached_to`: Physical or logical attachment (e.g., NIC attached to VM).
+-   `depends_on`: Direct functional dependency.
+-   `prerequisite_for`: Ordering in a learning path or deployment.
+-   `connects_to`: Network-level connectivity.
+-   `routes_to`: Traffic flow direction.
+-   `resolves_via`: Service resolution (e.g., DNS).
+-   `secures`: Security relationship (e.g., NSG secures Subnet).
+-   `monitors`: Observability relationship (e.g., Monitor monitors VM).
+-   `alternative_to`: Competitive or alternative service options.
+-   `related_to`: General conceptual association.
+
+## Evidence Model
+
+Every node and relationship in Azure Atlas is backed by **evidence**. Evidence consists of:
+
+-   **Source URL:** Direct link to the official MS Learn documentation page.
+-   **Excerpt:** A relevant text snippet from the documentation that supports the node's existence or relationship.
+-   **Last Verified:** Timestamp indicating when the evidence was last checked for accuracy.
+
+## Journey Model
+
+Journeys provide a guided narrative through the ontology. They consist of ordered steps that lead a user from a high-level objective to a specific set of architectural components and tasks.
+
+!!! tip "Ontology Growth"
+    The Azure Atlas ontology is designed to be extensible. New domains and services can be added by contributing SQL seed files and documentation excerpts.

--- a/docs/ontology/seed-data.md
+++ b/docs/ontology/seed-data.md
@@ -1,0 +1,43 @@
+# Seed Data
+
+Azure Atlas uses a declarative approach to populate the ontology. The content is stored in SQL seed files that can be applied to a fresh database or updated incrementally.
+
+## Seed File Location
+
+All seed data for the ontology is located in the `packages/ontology/` directory.
+
+-   `seed_domains.sql`: Definitions for the high-level domains (Network, Storage, Compute).
+-   `seed_nodes.sql`: Primary node definitions for each domain.
+-   `seed_edges.sql`: Relationship mapping between nodes.
+-   `seed_evidence.sql`: Links and excerpts from official MS Learn documentation.
+-   `seed_journeys.sql`: Curated learning paths and steps.
+
+## Applying Seeds
+
+Seeds are applied using the `migrate.py` script provided in the backend. You can apply seeds directly from the root directory:
+
+```bash
+# Run migrations and apply all seeds
+make migrate
+
+# Apply only the ontology seeds (skip migrations)
+python apps/api/scripts/migrate.py --seed-only
+```
+
+## Idempotency and Integrity
+
+The seeding process is designed to be safe to run multiple times:
+
+-   **Checksum-Based Skip:** The migration script calculates a checksum for each seed file. If the file has not changed, the script skips the seeding process for that file to save time.
+-   **Upsert Operations:** SQL `INSERT ... ON CONFLICT DO UPDATE` statements are used to ensure that existing nodes and relationships are updated with the latest information rather than duplicated.
+
+## Extending the Ontology
+
+To add a new domain or extend an existing one:
+
+1.  **Modify Seeds:** Add the new data to the appropriate `seed_*.sql` file in `packages/ontology/`.
+2.  **Verify Relationships:** Ensure that any new edges point to existing node IDs to maintain referential integrity.
+3.  **Run Seeding:** Execute `make reset-db` (for a fresh start) or `make migrate` (for an incremental update).
+
+!!! tip "ID Naming Convention"
+    Always use lower-case, hyphen-separated slugs for domain and node IDs (e.g., `virtual-network`, `blob-storage`) to ensure consistent URLs and query parameters.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,92 @@
+site_name: Azure Atlas
+site_description: Explore Azure as a knowledge map — ontology-based navigation for MS Learn
+site_url: https://yeongseon.github.io/azure-atlas
+repo_url: https://github.com/yeongseon/azure-atlas
+repo_name: yeongseon/azure-atlas
+edit_uri: edit/main/docs/
+
+theme:
+  name: material
+  palette:
+    - scheme: slate
+      primary: blue
+      accent: cyan
+      toggle:
+        icon: material/brightness-7
+        name: Switch to light mode
+    - scheme: default
+      primary: blue
+      accent: cyan
+      toggle:
+        icon: material/brightness-4
+        name: Switch to dark mode
+  features:
+    - navigation.instant
+    - navigation.tracking
+    - navigation.tabs
+    - navigation.sections
+    - navigation.expand
+    - navigation.top
+    - toc.follow
+    - search.suggest
+    - search.highlight
+    - content.code.copy
+    - content.code.annotate
+  icon:
+    repo: fontawesome/brands/github
+  font:
+    text: Inter
+    code: JetBrains Mono
+
+nav:
+  - Home: index.md
+  - Getting Started:
+    - Quickstart: getting-started/quickstart.md
+    - Prerequisites: getting-started/prerequisites.md
+    - Configuration: getting-started/configuration.md
+  - Architecture:
+    - Overview: architecture/overview.md
+    - API Reference: architecture/api.md
+    - Database Schema: architecture/database.md
+    - Frontend: architecture/frontend.md
+  - Ontology:
+    - Overview: ontology/overview.md
+    - Domains: ontology/domains.md
+    - Seed Data: ontology/seed-data.md
+  - Development:
+    - Setup: development/setup.md
+    - Testing: development/testing.md
+    - CI/CD: development/ci-cd.md
+  - Contributing: contributing.md
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.tasklist:
+      custom_checkbox: true
+  - attr_list
+  - md_in_html
+  - tables
+  - toc:
+      permalink: true
+
+plugins:
+  - search
+  - minify:
+      minify_html: true
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/yeongseon/azure-atlas

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,2 @@
+mkdocs-material>=9.5
+mkdocs-minify-plugin>=0.8


### PR DESCRIPTION
## Summary

- Add **MkDocs Material** documentation site with 15 pages covering architecture, getting started, ontology, development, and contributing
- Add **GitHub Actions workflow** (`.github/workflows/docs.yml`) for automatic docs deployment to GitHub Pages on push to `main`
- Update **README.md**: fix CI badge URL, add docs badge, update Cytoscape.js → React Flow references, add Documentation section with link to GitHub Pages
- Add `site/` and `.sisyphus/` to `.gitignore` to exclude build artifacts

## Documentation Structure

```
docs/
├── index.md                    # Landing page
├── getting-started/
│   ├── quickstart.md           # One-command setup
│   ├── prerequisites.md        # Requirements
│   └── configuration.md        # Environment variables
├── architecture/
│   ├── overview.md             # High-level architecture
│   ├── api.md                  # API endpoint reference
│   ├── database.md             # PostgreSQL schema
│   └── frontend.md             # React + React Flow
├── ontology/
│   ├── overview.md             # Ontology model
│   ├── domains.md              # Network/Storage/Compute
│   └── seed-data.md            # YAML seed format
├── development/
│   ├── setup.md                # Dev environment
│   ├── testing.md              # Test strategies
│   └── ci-cd.md                # GitHub Actions
└── contributing.md             # Contribution guide
```

## Deployment

Docs are deployed to **https://yeongseon.github.io/azure-atlas** via GitHub Pages on every push to `main` that touches `docs/`, `mkdocs.yml`, or `requirements-docs.txt`.