### PR TITLE
feat(web): add static demo mode for GitHub Pages deployment

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -1,0 +1,66 @@
+name: Demo
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'apps/web/**'
+      - 'packages/ontology/**'
+      - '.github/workflows/demo.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.29.3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v5
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Export demo data
+        run: pnpm export-demo-data
+
+      - name: Build demo app
+        run: pnpm --filter azure-atlas-web build:demo
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: apps/web/dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ node_modules/
 .env
 .env.*
 !.env.example
+!.env.demo
 dist/
 .DS_Store
 *.egg-info/
@@ -37,6 +38,9 @@ uv.lock
 tsconfig.tsbuildinfo
 apps/web/tsconfig.tsbuildinfo
 site/
+
+# Demo data (generated)
+apps/web/public/data/atlas.json
 
 # Sisyphus agent state
 .sisyphus/

--- a/apps/web/.env.demo
+++ b/apps/web/.env.demo
@@ -1,0 +1,1 @@
+VITE_ATLAS_MODE=static

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
+    "build:demo": "tsc -b && vite build --mode demo",
     "preview": "vite preview",
     "lint": "eslint src",
     "typecheck": "tsc --noEmit",

--- a/apps/web/src/lib/api/dataset.ts
+++ b/apps/web/src/lib/api/dataset.ts
@@ -1,0 +1,125 @@
+import type {
+  DomainSummary,
+  EdgeSummary,
+  EvidenceItem,
+  JourneyStep,
+  JourneySummary,
+} from './types'
+
+interface AtlasMeta {
+  version: string
+  generated_at: string
+  counts: {
+    domains: number
+    nodes: number
+    edges: number
+    evidence: number
+    journeys: number
+    journey_steps: number
+  }
+}
+
+export interface AtlasNodeRecord {
+  node_id: string
+  domain_id: string
+  label: string
+  node_type: string
+  summary: string | null
+  detail_md: string | null
+}
+
+export interface AtlasJourneyStepRecord extends JourneyStep {
+  journey_id: string
+}
+
+export interface AtlasDataset {
+  meta: AtlasMeta
+  domains: DomainSummary[]
+  nodes: AtlasNodeRecord[]
+  edges: EdgeSummary[]
+  evidence: EvidenceItem[]
+  journeys: JourneySummary[]
+  journeySteps: AtlasJourneyStepRecord[]
+}
+
+export interface LoadedAtlasDataset extends AtlasDataset {
+  nodesById: Map<string, AtlasNodeRecord>
+  edgesByNodeId: Map<string, EdgeSummary[]>
+  evidenceByNodeId: Map<string, EvidenceItem[]>
+  journeyStepsById: Map<string, JourneyStep[]>
+  evidenceCountByNodeId: Map<string, number>
+}
+
+const DATA_URL = `${import.meta.env.BASE_URL}data/atlas.json`
+
+let datasetPromise: Promise<LoadedAtlasDataset> | null = null
+
+function pushMapValue<T>(map: Map<string, T[]>, key: string, value: T): void {
+  const existing = map.get(key)
+  if (existing) {
+    existing.push(value)
+    return
+  }
+  map.set(key, [value])
+}
+
+function buildLookupMaps(dataset: AtlasDataset): LoadedAtlasDataset {
+  const nodesById = new Map<string, AtlasNodeRecord>()
+  const edgesByNodeId = new Map<string, EdgeSummary[]>()
+  const evidenceByNodeId = new Map<string, EvidenceItem[]>()
+  const journeyStepsById = new Map<string, JourneyStep[]>()
+  const evidenceCountByNodeId = new Map<string, number>()
+
+  dataset.nodes.forEach(node => {
+    nodesById.set(node.node_id, node)
+  })
+
+  dataset.edges.forEach(edge => {
+    pushMapValue(edgesByNodeId, edge.source_id, edge)
+    pushMapValue(edgesByNodeId, edge.target_id, edge)
+  })
+
+  dataset.evidence.forEach(item => {
+    pushMapValue(evidenceByNodeId, item.node_id, item)
+  })
+
+  dataset.nodes.forEach(node => {
+    evidenceCountByNodeId.set(node.node_id, evidenceByNodeId.get(node.node_id)?.length ?? 0)
+  })
+
+  dataset.journeySteps.forEach(step => {
+    pushMapValue(journeyStepsById, step.journey_id, {
+      step_order: step.step_order,
+      node_id: step.node_id,
+      label: step.label,
+      narrative: step.narrative,
+    })
+  })
+
+  journeyStepsById.forEach(steps => {
+    steps.sort((left, right) => left.step_order - right.step_order)
+  })
+
+  return {
+    ...dataset,
+    nodesById,
+    edgesByNodeId,
+    evidenceByNodeId,
+    journeyStepsById,
+    evidenceCountByNodeId,
+  }
+}
+
+async function fetchAtlasDataset(): Promise<LoadedAtlasDataset> {
+  const res = await fetch(DATA_URL)
+  if (!res.ok) throw new Error(`API error ${res.status}: ${DATA_URL}`)
+  const dataset = (await res.json()) as AtlasDataset
+  return buildLookupMaps(dataset)
+}
+
+export function loadAtlasDataset(): Promise<LoadedAtlasDataset> {
+  if (!datasetPromise) {
+    datasetPromise = fetchAtlasDataset()
+  }
+  return datasetPromise
+}

--- a/apps/web/src/lib/api/http.ts
+++ b/apps/web/src/lib/api/http.ts
@@ -1,0 +1,45 @@
+import type {
+  ApiClient,
+  DomainDetail,
+  DomainSummary,
+  EvidenceItem,
+  JourneyDetail,
+  JourneySummary,
+  NodeDetail,
+  SearchResponse,
+  SubgraphResponse,
+} from './types'
+
+const BASE = import.meta.env.VITE_API_URL ?? '/api/v1'
+
+async function apiFetch<T>(path: string): Promise<T> {
+  const res = await fetch(`${BASE}${path}`)
+  if (!res.ok) throw new Error(`API error ${res.status}: ${path}`)
+  return res.json() as Promise<T>
+}
+
+export function createHttpClient(): ApiClient {
+  return {
+    listDomains: () => apiFetch<{ domains: DomainSummary[] }>('/domains'),
+    getDomain: (id: string) => apiFetch<DomainDetail>(`/domains/${id}`),
+    getNode: (id: string) => apiFetch<NodeDetail>(`/nodes/${id}`),
+    getSubgraph: (id: string, depth = 1, relationTypes?: string[]) => {
+      const params = new URLSearchParams({ depth: String(depth) })
+      if (relationTypes?.length) {
+        relationTypes.forEach(type => {
+          params.append('relation_types', type)
+        })
+      }
+      return apiFetch<SubgraphResponse>(`/nodes/${id}/subgraph?${params}`)
+    },
+    getEvidence: (id: string) =>
+      apiFetch<{ node_id: string; evidence: EvidenceItem[] }>(`/nodes/${id}/evidence`),
+    search: (q: string, limit = 20, nodeType?: string) => {
+      const params = new URLSearchParams({ q, limit: String(limit) })
+      if (nodeType) params.set('node_type', nodeType)
+      return apiFetch<SearchResponse>(`/search?${params}`)
+    },
+    listJourneys: () => apiFetch<{ journeys: JourneySummary[] }>('/journeys'),
+    getJourney: (id: string) => apiFetch<JourneyDetail>(`/journeys/${id}`),
+  }
+}

--- a/apps/web/src/lib/api/index.ts
+++ b/apps/web/src/lib/api/index.ts
@@ -1,0 +1,9 @@
+import { createHttpClient } from './http'
+import { createStaticClient } from './static'
+import type { ApiClient } from './types'
+
+export * from './types'
+
+const mode = import.meta.env.VITE_ATLAS_MODE
+
+export const api: ApiClient = mode === 'static' ? createStaticClient() : createHttpClient()

--- a/apps/web/src/lib/api/search.ts
+++ b/apps/web/src/lib/api/search.ts
@@ -1,0 +1,59 @@
+import type { LoadedAtlasDataset } from './dataset'
+import type { NodePreview } from './types'
+
+interface SearchMatch {
+  node: NodePreview
+  score: number
+}
+
+function getScore(label: string, summary: string | null, query: string): number {
+  if (label === query) return 100
+  if (label.startsWith(query)) return 80
+  if (label.includes(query)) return 60
+  if (summary?.includes(query)) return 40
+  return -1
+}
+
+function collectMatches(
+  dataset: LoadedAtlasDataset,
+  query: string,
+  nodeType?: string,
+): SearchMatch[] {
+  const normalizedQuery = query.trim().toLocaleLowerCase()
+  if (!normalizedQuery) return []
+
+  return dataset.nodes
+    .filter(node => !nodeType || node.node_type === nodeType)
+    .map(node => {
+      const score = getScore(
+        node.label.toLocaleLowerCase(),
+        node.summary?.toLocaleLowerCase() ?? null,
+        normalizedQuery,
+      )
+
+      return score >= 0
+        ? {
+            node: {
+              node_id: node.node_id,
+              label: node.label,
+              node_type: node.node_type,
+              summary: node.summary,
+            },
+            score,
+          }
+        : null
+    })
+    .filter((match): match is SearchMatch => match !== null)
+    .sort((left, right) => right.score - left.score || left.node.label.localeCompare(right.node.label))
+}
+
+export function searchNodes(
+  dataset: LoadedAtlasDataset,
+  query: string,
+  limit: number,
+  nodeType?: string,
+): NodePreview[] {
+  return collectMatches(dataset, query, nodeType)
+    .slice(0, limit)
+    .map(match => match.node)
+}

--- a/apps/web/src/lib/api/static.ts
+++ b/apps/web/src/lib/api/static.ts
@@ -1,0 +1,147 @@
+import type { LoadedAtlasDataset } from './dataset'
+import { loadAtlasDataset } from './dataset'
+import { searchNodes } from './search'
+import { computeSubgraph } from './subgraph'
+import type {
+  ApiClient,
+  DomainDetail,
+  JourneyDetail,
+  NodeDetail,
+  NodePreview,
+  SearchResponse,
+} from './types'
+
+function toNodePreview(dataset: LoadedAtlasDataset, nodeId: string): NodePreview & { evidence_count: number }
+function toNodePreview(dataset: LoadedAtlasDataset, nodeId: string, includeEvidenceCount: false): NodePreview
+function toNodePreview(
+  dataset: LoadedAtlasDataset,
+  nodeId: string,
+  includeEvidenceCount = true,
+): NodePreview | (NodePreview & { evidence_count: number }) {
+  const node = dataset.nodesById.get(nodeId)
+  if (!node) throw new Error(`API error 404: /nodes/${nodeId}`)
+
+  const preview: NodePreview = {
+    node_id: node.node_id,
+    label: node.label,
+    node_type: node.node_type,
+    summary: node.summary,
+  }
+
+  if (!includeEvidenceCount) {
+    return preview
+  }
+
+  return {
+    ...preview,
+    evidence_count: dataset.evidenceCountByNodeId.get(node.node_id) ?? 0,
+  }
+}
+
+function requireDomain(dataset: LoadedAtlasDataset, domainId: string) {
+  const domain = dataset.domains.find(item => item.domain_id === domainId)
+  if (!domain) throw new Error(`API error 404: /domains/${domainId}`)
+  return domain
+}
+
+function requireJourney(dataset: LoadedAtlasDataset, journeyId: string) {
+  const journey = dataset.journeys.find(item => item.journey_id === journeyId)
+  if (!journey) throw new Error(`API error 404: /journeys/${journeyId}`)
+  return journey
+}
+
+function buildDomainDetail(dataset: LoadedAtlasDataset, domainId: string): DomainDetail {
+  const domain = requireDomain(dataset, domainId)
+  const nodes = dataset.nodes
+    .filter(node => node.domain_id === domainId)
+    .map(node => toNodePreview(dataset, node.node_id))
+  const nodeIds = new Set(nodes.map(node => node.node_id))
+  const edges = dataset.edges.filter(
+    edge => nodeIds.has(edge.source_id) && nodeIds.has(edge.target_id),
+  )
+
+  return {
+    domain,
+    nodes,
+    edges,
+    node_count: nodes.length,
+  }
+}
+
+function buildNodeDetail(dataset: LoadedAtlasDataset, nodeId: string): NodeDetail {
+  const node = dataset.nodesById.get(nodeId)
+  if (!node) throw new Error(`API error 404: /nodes/${nodeId}`)
+
+  return {
+    node: {
+      node_id: node.node_id,
+      domain_id: node.domain_id,
+      label: node.label,
+      node_type: node.node_type,
+      summary: node.summary,
+      detail_md: node.detail_md,
+    },
+  }
+}
+
+function buildJourneyDetail(dataset: LoadedAtlasDataset, journeyId: string): JourneyDetail {
+  const journey = requireJourney(dataset, journeyId)
+  return {
+    journey,
+    steps: dataset.journeyStepsById.get(journeyId) ?? [],
+  }
+}
+
+async function buildSearchResponse(
+  dataset: LoadedAtlasDataset,
+  q: string,
+  limit: number,
+  nodeType?: string,
+): Promise<SearchResponse> {
+  return {
+    query: q,
+    results: searchNodes(dataset, q, limit, nodeType),
+    total: searchNodes(dataset, q, Number.MAX_SAFE_INTEGER, nodeType).length,
+  }
+}
+
+export function createStaticClient(): ApiClient {
+  return {
+    async listDomains() {
+      const dataset = await loadAtlasDataset()
+      return { domains: dataset.domains }
+    },
+    async getDomain(id: string) {
+      const dataset = await loadAtlasDataset()
+      return buildDomainDetail(dataset, id)
+    },
+    async getNode(id: string) {
+      const dataset = await loadAtlasDataset()
+      return buildNodeDetail(dataset, id)
+    },
+    async getSubgraph(id: string, depth = 1, relationTypes?: string[]) {
+      const dataset = await loadAtlasDataset()
+      return computeSubgraph(dataset, id, depth, relationTypes)
+    },
+    async getEvidence(id: string) {
+      const dataset = await loadAtlasDataset()
+      if (!dataset.nodesById.has(id)) throw new Error(`API error 404: /nodes/${id}/evidence`)
+      return {
+        node_id: id,
+        evidence: dataset.evidenceByNodeId.get(id) ?? [],
+      }
+    },
+    async search(q: string, limit = 20, nodeType?: string) {
+      const dataset = await loadAtlasDataset()
+      return buildSearchResponse(dataset, q, limit, nodeType)
+    },
+    async listJourneys() {
+      const dataset = await loadAtlasDataset()
+      return { journeys: dataset.journeys }
+    },
+    async getJourney(id: string) {
+      const dataset = await loadAtlasDataset()
+      return buildJourneyDetail(dataset, id)
+    },
+  }
+}

--- a/apps/web/src/lib/api/subgraph.ts
+++ b/apps/web/src/lib/api/subgraph.ts
@@ -1,0 +1,64 @@
+import type { LoadedAtlasDataset } from './dataset'
+import type { EdgeSummary, SubgraphResponse } from './types'
+
+function clampDepth(depth: number): number {
+  return Math.max(1, Math.min(3, depth))
+}
+
+function isAllowedEdge(edge: EdgeSummary, relationTypes?: Set<string>): boolean {
+  return !relationTypes || relationTypes.has(edge.relation_type)
+}
+
+export function computeSubgraph(
+  dataset: LoadedAtlasDataset,
+  nodeId: string,
+  depth: number,
+  relationTypes?: string[],
+): SubgraphResponse {
+  const centerNode = dataset.nodesById.get(nodeId)
+  if (!centerNode) throw new Error(`API error 404: /nodes/${nodeId}/subgraph`)
+
+  const discoveredNodeIds = new Set<string>([nodeId])
+  const queue: Array<{ nodeId: string; depth: number }> = [{ nodeId, depth: 0 }]
+  const maxDepth = clampDepth(depth)
+  const allowedRelationTypes = relationTypes?.length ? new Set(relationTypes) : undefined
+
+  while (queue.length > 0) {
+    const current = queue.shift()
+    if (!current || current.depth >= maxDepth) continue
+
+    const adjacentEdges = dataset.edgesByNodeId.get(current.nodeId) ?? []
+    adjacentEdges.forEach(edge => {
+      if (!isAllowedEdge(edge, allowedRelationTypes)) return
+
+      const nextNodeId = edge.source_id === current.nodeId ? edge.target_id : edge.source_id
+      if (discoveredNodeIds.has(nextNodeId)) return
+
+      discoveredNodeIds.add(nextNodeId)
+      queue.push({ nodeId: nextNodeId, depth: current.depth + 1 })
+    })
+  }
+
+  const nodes = dataset.nodes
+    .filter(node => discoveredNodeIds.has(node.node_id))
+    .map(node => ({
+      node_id: node.node_id,
+      label: node.label,
+      node_type: node.node_type,
+      summary: node.summary,
+      evidence_count: dataset.evidenceCountByNodeId.get(node.node_id) ?? 0,
+    }))
+
+  const edges = dataset.edges.filter(
+    edge =>
+      discoveredNodeIds.has(edge.source_id) &&
+      discoveredNodeIds.has(edge.target_id) &&
+      isAllowedEdge(edge, allowedRelationTypes),
+  )
+
+  return {
+    center_node_id: centerNode.node_id,
+    nodes,
+    edges,
+  }
+}

--- a/apps/web/src/lib/api/types.ts
+++ b/apps/web/src/lib/api/types.ts
@@ -1,11 +1,3 @@
-const BASE = import.meta.env.VITE_API_URL ?? '/api/v1'
-
-async function apiFetch<T>(path: string): Promise<T> {
-  const res = await fetch(`${BASE}${path}`)
-  if (!res.ok) throw new Error(`API error ${res.status}: ${path}`)
-  return res.json() as Promise<T>
-}
-
 export interface NodePreview {
   node_id: string
   label: string
@@ -81,24 +73,13 @@ export interface JourneyDetail {
   steps: JourneyStep[]
 }
 
-export const api = {
-  listDomains: () => apiFetch<{ domains: DomainSummary[] }>('/domains'),
-  getDomain: (id: string) => apiFetch<DomainDetail>(`/domains/${id}`),
-  getNode: (id: string) => apiFetch<NodeDetail>(`/nodes/${id}`),
-  getSubgraph: (id: string, depth = 1, relationTypes?: string[]) => {
-    const params = new URLSearchParams({ depth: String(depth) })
-    if (relationTypes?.length) {
-      relationTypes.forEach(t => { params.append('relation_types', t) })
-    }
-    return apiFetch<SubgraphResponse>(`/nodes/${id}/subgraph?${params}`)
-  },
-  getEvidence: (id: string) =>
-    apiFetch<{ node_id: string; evidence: EvidenceItem[] }>(`/nodes/${id}/evidence`),
-  search: (q: string, limit = 20, nodeType?: string) => {
-    const params = new URLSearchParams({ q, limit: String(limit) })
-    if (nodeType) params.set('node_type', nodeType)
-    return apiFetch<SearchResponse>(`/search?${params}`)
-  },
-  listJourneys: () => apiFetch<{ journeys: JourneySummary[] }>('/journeys'),
-  getJourney: (id: string) => apiFetch<JourneyDetail>(`/journeys/${id}`),
+export interface ApiClient {
+  listDomains(): Promise<{ domains: DomainSummary[] }>
+  getDomain(id: string): Promise<DomainDetail>
+  getNode(id: string): Promise<NodeDetail>
+  getSubgraph(id: string, depth?: number, relationTypes?: string[]): Promise<SubgraphResponse>
+  getEvidence(id: string): Promise<{ node_id: string; evidence: EvidenceItem[] }>
+  search(q: string, limit?: number, nodeType?: string): Promise<SearchResponse>
+  listJourneys(): Promise<{ journeys: JourneySummary[] }>
+  getJourney(id: string): Promise<JourneyDetail>
 }

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,9 +1,11 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { BrowserRouter } from 'react-router-dom'
+import { BrowserRouter, HashRouter } from 'react-router-dom'
 import App from './App'
 import './index.css'
+
+const Router = import.meta.env.VITE_ATLAS_MODE === 'static' ? HashRouter : BrowserRouter
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -14,12 +16,18 @@ const queryClient = new QueryClient({
   },
 })
 
-createRoot(document.getElementById('root')!).render(
+const rootElement = document.getElementById('root')
+
+if (!rootElement) {
+  throw new Error('Root element not found')
+}
+
+createRoot(rootElement).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
-      <BrowserRouter>
+      <Router>
         <App />
-      </BrowserRouter>
+      </Router>
     </QueryClientProvider>
   </StrictMode>,
 )

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,20 +1,24 @@
 /// <reference types="vitest/config" />
-import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vite'
 
-export default defineConfig({
+export default defineConfig(({ command, mode }) => ({
+  base: mode === 'demo' ? '/azure-atlas/' : undefined,
   plugins: [react()],
   server: {
     port: 5173,
-    proxy: {
-      '/api/v1': {
-        target: process.env.VITE_API_PROXY_TARGET || 'http://localhost:8000',
-        changeOrigin: true,
-      },
-    },
+    proxy:
+      command === 'serve'
+        ? {
+            '/api/v1': {
+              target: process.env.VITE_API_PROXY_TARGET || 'http://localhost:8000',
+              changeOrigin: true,
+            },
+          }
+        : undefined,
   },
   test: {
     environment: 'node',
     include: ['src/**/*.test.ts'],
   },
-})
+}))

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "scripts": {
     "dev": "pnpm --filter azure-atlas-web dev",
     "build": "pnpm --filter azure-atlas-web build",
+    "build:demo": "node packages/ontology/scripts/export-demo-data.mjs && pnpm --filter azure-atlas-web build:demo",
+    "export-demo-data": "node packages/ontology/scripts/export-demo-data.mjs",
     "test": "pnpm --filter azure-atlas-web test",
     "lint": "pnpm --filter azure-atlas-web lint",
     "typecheck": "pnpm --filter azure-atlas-web typecheck"

--- a/packages/ontology/scripts/export-demo-data.mjs
+++ b/packages/ontology/scripts/export-demo-data.mjs
@@ -1,0 +1,347 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const repoRoot = path.resolve(__dirname, '../../..')
+
+const seedFiles = [
+  path.join(repoRoot, 'packages/ontology/seed_network.sql'),
+  path.join(repoRoot, 'packages/ontology/seed_storage.sql'),
+  path.join(repoRoot, 'packages/ontology/seed_compute.sql'),
+]
+
+const outputDir = path.join(repoRoot, 'apps/web/public/data')
+const outputFile = path.join(outputDir, 'atlas.json')
+const tablesToExport = new Set(['domains', 'nodes', 'edges', 'evidence', 'journeys', 'journey_steps'])
+
+function extractInsertStatements(sql) {
+  const statements = []
+  const headerRegex = /INSERT INTO\s+([a-z_]+)\s*\(([^)]+)\)\s*VALUES\s*/gi
+
+  let match = headerRegex.exec(sql)
+  while (match !== null) {
+    const [, table, columnsRaw] = match
+    const valuesStart = headerRegex.lastIndex
+    const statementEnd = findStatementTerminator(sql, valuesStart)
+
+    if (!tablesToExport.has(table)) {
+      headerRegex.lastIndex = statementEnd + 1
+      continue
+    }
+
+    const valuesRaw = sql.slice(valuesStart, statementEnd)
+    statements.push({
+      table,
+      columns: columnsRaw.split(',').map(column => column.trim()),
+      rows: parseValues(valuesRaw),
+    })
+
+    headerRegex.lastIndex = statementEnd + 1
+    match = headerRegex.exec(sql)
+  }
+
+  return statements
+}
+
+function findStatementTerminator(sql, startIndex) {
+  let index = startIndex
+  let inString = false
+
+  while (index < sql.length) {
+    const char = sql[index]
+
+    if (char === "'") {
+      if (inString && sql[index + 1] === "'") {
+        index += 2
+        continue
+      }
+
+      inString = !inString
+      index += 1
+      continue
+    }
+
+    if (!inString && char === ';') {
+      return index
+    }
+
+    index += 1
+  }
+
+  throw new Error('Could not find INSERT statement terminator')
+}
+
+function parseValues(valuesRaw) {
+  const rows = []
+  let index = 0
+
+  while (index < valuesRaw.length) {
+    index = skipSeparators(valuesRaw, index)
+    if (index >= valuesRaw.length) break
+
+    if (valuesRaw[index] !== '(') {
+      throw new Error(`Expected "(" while parsing VALUES at index ${index}`)
+    }
+
+    const { row, nextIndex } = parseRow(valuesRaw, index)
+    rows.push(row)
+    index = nextIndex
+  }
+
+  return rows
+}
+
+function skipSeparators(input, startIndex) {
+  let index = startIndex
+  while (index < input.length) {
+    const char = input[index]
+    if (char === ',' || /\s/.test(char)) {
+      index += 1
+      continue
+    }
+    break
+  }
+  return index
+}
+
+function parseRow(input, startIndex) {
+  const row = []
+  let index = startIndex + 1
+
+  while (index < input.length) {
+    index = skipWhitespace(input, index)
+    const { value, nextIndex } = parseValue(input, index)
+    row.push(value)
+    index = skipWhitespace(input, nextIndex)
+
+    if (input[index] === ',') {
+      index += 1
+      continue
+    }
+
+    if (input[index] === ')') {
+      return { row, nextIndex: index + 1 }
+    }
+
+    throw new Error(`Unexpected token "${input[index] ?? 'EOF'}" while parsing row at index ${index}`)
+  }
+
+  throw new Error('Unterminated row while parsing VALUES')
+}
+
+function skipWhitespace(input, startIndex) {
+  let index = startIndex
+  while (index < input.length && /\s/.test(input[index])) {
+    index += 1
+  }
+  return index
+}
+
+function parseValue(input, startIndex) {
+  if (input[startIndex] === "'") {
+    return parseQuotedString(input, startIndex)
+  }
+
+  let index = startIndex
+  while (index < input.length && input[index] !== ',' && input[index] !== ')') {
+    index += 1
+  }
+
+  const rawValue = input.slice(startIndex, index).trim()
+
+  if (/^null$/i.test(rawValue)) {
+    return { value: null, nextIndex: index }
+  }
+
+  if (/^-?\d+(?:\.\d+)?$/.test(rawValue)) {
+    return { value: Number(rawValue), nextIndex: index }
+  }
+
+  throw new Error(`Unsupported SQL value: ${rawValue}`)
+}
+
+function parseQuotedString(input, startIndex) {
+  let index = startIndex + 1
+  let value = ''
+
+  while (index < input.length) {
+    const char = input[index]
+
+    if (char === "'") {
+      if (input[index + 1] === "'") {
+        value += "'"
+        index += 2
+        continue
+      }
+
+      return { value, nextIndex: index + 1 }
+    }
+
+    value += char
+    index += 1
+  }
+
+  throw new Error('Unterminated SQL string literal')
+}
+
+function rowsToObjects(columns, rows) {
+  return rows.map((row) => {
+    if (row.length !== columns.length) {
+      throw new Error(`Column/value length mismatch: expected ${columns.length}, got ${row.length}`)
+    }
+
+    return Object.fromEntries(columns.map((column, index) => [column, row[index]]))
+  })
+}
+
+function buildAtlas(records) {
+  const duplicateNodeIds = new Set()
+  const nodeMap = new Map()
+  const domains = []
+  const edges = []
+  const evidence = []
+  const journeys = []
+  const journeySteps = []
+  const evidenceCounters = new Map()
+
+  for (const domain of records.domains) {
+    domains.push({
+      domain_id: domain.domain_id,
+      label: domain.label,
+      description: domain.description,
+      icon_url: null,
+      display_order: domain.display_order,
+    })
+  }
+
+  for (const node of records.nodes) {
+    if (nodeMap.has(node.node_id)) {
+      duplicateNodeIds.add(node.node_id)
+      continue
+    }
+
+    const atlasNode = {
+      node_id: node.node_id,
+      domain_id: node.domain_id,
+      label: node.label,
+      node_type: node.node_type,
+      summary: node.summary,
+      detail_md: null,
+    }
+
+    nodeMap.set(node.node_id, atlasNode)
+  }
+
+  for (const edge of records.edges) {
+    edges.push({
+      edge_id: `e-${edge.source_id}-${edge.target_id}-${edge.relation_type}`,
+      source_id: edge.source_id,
+      target_id: edge.target_id,
+      relation_type: edge.relation_type,
+      weight: edge.weight,
+    })
+  }
+
+  for (const item of records.evidence) {
+    const nextIndex = (evidenceCounters.get(item.node_id) ?? 0) + 1
+    evidenceCounters.set(item.node_id, nextIndex)
+    evidence.push({
+      evidence_id: `ev-${item.node_id}-${nextIndex}`,
+      node_id: item.node_id,
+      excerpt: item.excerpt,
+      source_url: item.source_url,
+      source_title: item.source_title,
+      confidence_score: item.confidence_score,
+    })
+  }
+
+  for (const journey of records.journeys) {
+    journeys.push({
+      journey_id: journey.journey_id,
+      domain_id: journey.domain_id,
+      title: journey.title,
+      description: journey.description,
+    })
+  }
+
+  for (const step of records.journey_steps) {
+    const node = nodeMap.get(step.node_id)
+    if (!node) {
+      throw new Error(`Journey step references missing node_id: ${step.node_id}`)
+    }
+
+    journeySteps.push({
+      journey_id: step.journey_id,
+      node_id: step.node_id,
+      step_order: step.step_order,
+      label: node.label,
+      narrative: step.narrative,
+    })
+  }
+
+  const atlas = {
+    meta: {
+      version: '1.0.0',
+      generated_at: new Date().toISOString(),
+      counts: {
+        domains: domains.length,
+        nodes: nodeMap.size,
+        edges: edges.length,
+        evidence: evidence.length,
+        journeys: journeys.length,
+        journey_steps: journeySteps.length,
+      },
+    },
+    domains: domains.sort((a, b) => a.display_order - b.display_order),
+    nodes: [...nodeMap.values()],
+    edges,
+    evidence,
+    journeys,
+    journeySteps,
+  }
+
+  return { atlas, duplicateNodeIds: [...duplicateNodeIds].sort() }
+}
+
+async function main() {
+  const records = {
+    domains: [],
+    nodes: [],
+    edges: [],
+    evidence: [],
+    journeys: [],
+    journey_steps: [],
+  }
+
+  for (const seedFile of seedFiles) {
+    const sql = await readFile(seedFile, 'utf8')
+
+    for (const statement of extractInsertStatements(sql)) {
+      records[statement.table].push(...rowsToObjects(statement.columns, statement.rows))
+    }
+  }
+
+  const { atlas, duplicateNodeIds } = buildAtlas(records)
+
+  await mkdir(outputDir, { recursive: true })
+  await writeFile(outputFile, `${JSON.stringify(atlas, null, 2)}\n`, 'utf8')
+
+  console.log(`Exported demo data to ${path.relative(repoRoot, outputFile)}`)
+  console.log(`Domains: ${atlas.meta.counts.domains}`)
+  console.log(`Nodes: ${atlas.meta.counts.nodes}`)
+  console.log(`Edges: ${atlas.meta.counts.edges}`)
+  console.log(`Evidence: ${atlas.meta.counts.evidence}`)
+  console.log(`Journeys: ${atlas.meta.counts.journeys}`)
+  console.log(`Journey steps: ${atlas.meta.counts.journey_steps}`)
+
+  if (duplicateNodeIds.length > 0) {
+    console.warn(`Deduplicated ${duplicateNodeIds.length} duplicate node_id values: ${duplicateNodeIds.join(', ')}`)
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error)
+  process.exitCode = 1
+})


### PR DESCRIPTION
## Summary

Add a fully functional static demo mode that runs the entire frontend without a backend, deployable to GitHub Pages.

- **Demo data exporter** — parses seed SQL → `atlas.json` with all 136 nodes, 257 edges, 548 evidence items, 25 journeys
- **Pluggable API layer** — `ApiClient` interface with `http` (production) and `static` (demo) implementations, selected via `VITE_ATLAS_MODE`
- **Client-side search** — in-memory scoring (exact > prefix > contains > summary) with node_type filter
- **BFS subgraph** — browser-side graph traversal with depth 1–3 and relation_type filtering
- **Demo build target** — `pnpm build:demo` with HashRouter and `/azure-atlas/` base path
- **GitHub Actions workflow** — automatic demo deployment to GitHub Pages

## Architecture

```
[Build time]
seed SQL → export-demo-data.mjs → atlas.json

[Runtime — GitHub Pages]
atlas.json → browser memory → static.ts (same ApiClient interface)
                                ├─ search.ts (in-memory scorer)
                                └─ subgraph.ts (BFS traversal)
```

## Module structure

```
packages/ontology/scripts/export-demo-data.mjs   # Seed SQL parser → JSON

apps/web/src/lib/api/
  types.ts          # Shared interfaces + ApiClient contract
  index.ts          # Mode selector (VITE_ATLAS_MODE)
  http.ts           # Production HTTP client
  static.ts         # Demo client (atlas.json)
  dataset.ts        # JSON loader + in-memory maps
  search.ts         # Client-side search scorer
  subgraph.ts       # BFS subgraph computation
```

## Verification

- [x] `pnpm typecheck` — pass
- [x] `pnpm lint` — pass
- [x] `pnpm build` — production build unchanged
- [x] `pnpm build:demo` — demo build with correct base path
- [x] Demo build output references `/azure-atlas/assets/...`
- [x] HashRouter in demo mode, BrowserRouter in production

## Related issues

Closes #26, closes #27, closes #28, closes #29