### PR TITLE
fix: address code review issues #30–#35

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,20 +27,10 @@ jobs:
         uses: astral-sh/setup-uv@v5
 
       - name: Install API dependencies
-        run: |
-          if [ -f pyproject.toml ]; then
-            uv sync --dev
-          else
-            echo "apps/api/pyproject.toml not found; skipping dependency install"
-          fi
+        run: uv sync --extra dev
 
       - name: Ruff check
-        run: |
-          if [ -f pyproject.toml ]; then
-            uv run ruff check .
-          else
-            echo "apps/api/pyproject.toml not found; skipping ruff"
-          fi
+        run: uv run ruff check .
 
   test-api:
     runs-on: ubuntu-latest
@@ -60,20 +50,10 @@ jobs:
         uses: astral-sh/setup-uv@v5
 
       - name: Install API dependencies
-        run: |
-          if [ -f pyproject.toml ]; then
-            uv sync --dev
-          else
-            echo "apps/api/pyproject.toml not found; skipping dependency install"
-          fi
+        run: uv sync --extra dev
 
       - name: Pytest
-        run: |
-          if [ -f pyproject.toml ]; then
-            uv run pytest
-          else
-            echo "apps/api/pyproject.toml not found; skipping pytest"
-          fi
+        run: uv run pytest
 
   lint-web:
     runs-on: ubuntu-latest
@@ -86,8 +66,6 @@ jobs:
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -96,20 +74,10 @@ jobs:
           cache: pnpm
 
       - name: Install web dependencies
-        run: |
-          if [ -f package.json ]; then
-            pnpm install --frozen-lockfile
-          else
-            echo "apps/web/package.json not found; skipping install"
-          fi
+        run: pnpm install --frozen-lockfile
 
       - name: ESLint
-        run: |
-          if [ -f package.json ]; then
-            pnpm exec eslint .
-          else
-            echo "apps/web/package.json not found; skipping eslint"
-          fi
+        run: pnpm lint
 
   typecheck-web:
     runs-on: ubuntu-latest
@@ -122,8 +90,6 @@ jobs:
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -148,8 +114,6 @@ jobs:
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -158,17 +122,7 @@ jobs:
           cache: pnpm
 
       - name: Install web dependencies
-        run: |
-          if [ -f package.json ]; then
-            pnpm install --frozen-lockfile
-          else
-            echo "apps/web/package.json not found; skipping install"
-          fi
+        run: pnpm install --frozen-lockfile
 
       - name: Build web
-        run: |
-          if [ -f package.json ]; then
-            pnpm build
-          else
-            echo "apps/web/package.json not found; skipping build"
-          fi
+        run: pnpm build

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Azure Atlas
 
-![CI](https://github.com/{owner}/{repo}/actions/workflows/ci.yml/badge.svg)
+![CI](https://github.com/yeongseon/azure-atlas/actions/workflows/ci.yml/badge.svg)
 
 > Explore Azure as a knowledge map.
 
@@ -11,9 +11,9 @@ An ontology-based knowledge map of Azure, built on official MS Learn documentati
 - **API**: Python 3.12 + FastAPI + asyncpg
 - **DB**: PostgreSQL 16
 - **Search**: PostgreSQL FTS (pg_trgm)
-- **Frontend**: React 18 + Vite + TypeScript + Cytoscape.js + TanStack Query
-- **Worker**: ARQ (async Redis Queue)
-- **Cache**: Redis
+- **Frontend**: React 18 + Vite + TypeScript + React Flow (@xyflow/react) + TanStack Query
+- **Worker**: ARQ (async Redis Queue) — *stub, not yet wired*
+- **Cache**: Redis — *used by ARQ; not required for core functionality*
 
 ## Structure
 
@@ -30,10 +30,10 @@ azure-atlas/
 
 The project follows a standard multi-tier architecture:
 
-- **Frontend**: React SPA using Cytoscape.js for graph visualization.
-- **API**: FastAPI providing RESTful endpoints and managing background tasks.
+- **Frontend**: React SPA using React Flow for graph visualization.
+- **API**: FastAPI providing RESTful endpoints.
 - **Database**: PostgreSQL with FTS (pg_trgm) for full-text search and relational data.
-- **Cache/Queue**: Redis for state management and ARQ background workers.
+- **Cache/Queue**: Redis + ARQ for background workers — *stub, not yet active*.
 
 Data Flow: Browser (React SPA) → API (FastAPI) → Database (PostgreSQL)
 

--- a/apps/api/app/migrate.py
+++ b/apps/api/app/migrate.py
@@ -36,7 +36,9 @@ async def _ensure_table(conn: asyncpg.Connection) -> None:
     await conn.execute(MIGRATIONS_TABLE_UPGRADE)
 
 
-async def _run_schema(conn: asyncpg.Connection, *, dry_run: bool = False) -> None:
+async def _run_schema(
+    conn: asyncpg.Connection, *, dry_run: bool = False, strict: bool = False
+) -> None:
     sql_files = sorted(MIGRATIONS_DIR.glob("*.sql"))
     if not sql_files:
         print("No schema migrations found.")
@@ -51,7 +53,10 @@ async def _run_schema(conn: asyncpg.Connection, *, dry_run: bool = False) -> Non
 
         if row is not None:
             if row["checksum"] and row["checksum"] != checksum:
-                print(f"WARNING: {sql_file.name} has changed since last applied")
+                msg = f"CHECKSUM MISMATCH: {sql_file.name} has changed since last applied"
+                if strict:
+                    raise RuntimeError(msg)
+                print(f"WARNING: {msg}")
             print(f"skip {sql_file.name} (already applied)")
             continue
 
@@ -69,7 +74,9 @@ async def _run_schema(conn: asyncpg.Connection, *, dry_run: bool = False) -> Non
         print(f"applied {sql_file.name}")
 
 
-async def _run_seeds(conn: asyncpg.Connection, *, dry_run: bool = False) -> None:
+async def _run_seeds(
+    conn: asyncpg.Connection, *, dry_run: bool = False, strict: bool = False
+) -> None:
     seed_files = sorted(ONTOLOGY_DIR.glob("seed_*.sql"))
     if not seed_files:
         print("No seed files found.")
@@ -84,7 +91,10 @@ async def _run_seeds(conn: asyncpg.Connection, *, dry_run: bool = False) -> None
 
         if row is not None:
             if row["checksum"] and row["checksum"] != checksum:
-                print(f"WARNING: {seed_file.name} has changed since last applied")
+                msg = f"CHECKSUM MISMATCH: {seed_file.name} has changed since last applied"
+                if strict:
+                    raise RuntimeError(msg)
+                print(f"WARNING: {msg}")
             print(f"skip {seed_file.name} (already applied)")
             continue
 
@@ -103,7 +113,11 @@ async def _run_seeds(conn: asyncpg.Connection, *, dry_run: bool = False) -> None
 
 
 async def run_migrations(
-    *, schema_only: bool = False, seed_only: bool = False, dry_run: bool = False
+    *,
+    schema_only: bool = False,
+    seed_only: bool = False,
+    dry_run: bool = False,
+    strict: bool = False,
 ) -> None:
     db_url = os.environ["DATABASE_URL"]
     conn = await asyncpg.connect(db_url)
@@ -111,12 +125,12 @@ async def run_migrations(
         await _ensure_table(conn)
 
         if seed_only:
-            await _run_seeds(conn, dry_run=dry_run)
+            await _run_seeds(conn, dry_run=dry_run, strict=strict)
         elif schema_only:
-            await _run_schema(conn, dry_run=dry_run)
+            await _run_schema(conn, dry_run=dry_run, strict=strict)
         else:
-            await _run_schema(conn, dry_run=dry_run)
-            await _run_seeds(conn, dry_run=dry_run)
+            await _run_schema(conn, dry_run=dry_run, strict=strict)
+            await _run_seeds(conn, dry_run=dry_run, strict=strict)
     finally:
         await conn.close()
 
@@ -125,10 +139,12 @@ if __name__ == "__main__":
     schema_only = "--schema-only" in sys.argv
     seed_only = "--seed-only" in sys.argv
     dry_run = "--dry-run" in sys.argv
+    strict = "--strict" in sys.argv
     asyncio.run(
         run_migrations(
             schema_only=schema_only,
             seed_only=seed_only,
             dry_run=dry_run,
+            strict=strict,
         )
     )

--- a/apps/api/app/routers/curation.py
+++ b/apps/api/app/routers/curation.py
@@ -54,4 +54,16 @@ async def create_decision(body: CurationDecisionRequest) -> CurationDecisionResp
                 if not updated:
                     raise HTTPException(status_code=404, detail="Evidence not found")
 
+            await conn.execute(
+                "INSERT INTO curation_decisions"
+                " (node_id, edge_id, evidence_id, decision, new_status, reviewer_note)"
+                " VALUES ($1, $2, $3::uuid, $4, $5, $6)",
+                body.node_id,
+                body.edge_id,
+                body.evidence_id,
+                body.decision,
+                new_status,
+                body.reviewer_note,
+            )
+
     return CurationDecisionResponse(ok=True)

--- a/apps/api/app/routers/domains.py
+++ b/apps/api/app/routers/domains.py
@@ -53,7 +53,7 @@ async def get_domain(domain_id: str) -> DomainDetailResponse:
             FROM edges e
             JOIN nodes src ON src.node_id = e.source_id AND src.status = 'approved'
             JOIN nodes tgt ON tgt.node_id = e.target_id AND tgt.status = 'approved'
-            WHERE src.domain_id = $1 AND e.status = 'approved'
+            WHERE src.domain_id = $1 AND tgt.domain_id = $1 AND e.status = 'approved'
             """,
             domain_id,
         )

--- a/apps/api/entrypoint.sh
+++ b/apps/api/entrypoint.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-echo "Running schema migrations…"
-python -m app.migrate --schema-only
+echo "Running migrations (schema + seeds)…"
+python -m app.migrate
 echo "Migrations complete."
 
 exec "$@"

--- a/apps/api/migrations/002_curation_audit.sql
+++ b/apps/api/migrations/002_curation_audit.sql
@@ -1,0 +1,22 @@
+BEGIN;
+
+CREATE TABLE curation_decisions (
+    decision_id      UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    node_id          TEXT REFERENCES nodes(node_id) ON DELETE CASCADE,
+    edge_id          UUID REFERENCES edges(edge_id) ON DELETE CASCADE,
+    evidence_id      UUID REFERENCES evidence(evidence_id) ON DELETE CASCADE,
+    decision         TEXT NOT NULL CHECK (decision IN ('approve', 'reject', 'needs_refresh')),
+    new_status       content_status_enum NOT NULL,
+    reviewer_note    TEXT,
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT curation_decisions_at_least_one CHECK (
+        node_id IS NOT NULL OR edge_id IS NOT NULL OR evidence_id IS NOT NULL
+    )
+);
+
+CREATE INDEX curation_decisions_node_id_idx ON curation_decisions(node_id);
+CREATE INDEX curation_decisions_edge_id_idx ON curation_decisions(edge_id);
+CREATE INDEX curation_decisions_evidence_id_idx ON curation_decisions(evidence_id);
+CREATE INDEX curation_decisions_created_at_idx ON curation_decisions(created_at DESC);
+
+COMMIT;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview",
     "lint": "eslint src",
     "typecheck": "tsc --noEmit",
-    "test": "echo 'No unit tests yet' && exit 0"
+    "test": "vitest run"
   },
   "dependencies": {
     "@dagrejs/dagre": "^3.0.0",
@@ -22,6 +22,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.9.0",
+    "@testing-library/jest-dom": "^6.9.1",
     "@types/react": "^18.3.5",
     "@types/react-dom": "^18.3.0",
     "@typescript-eslint/eslint-plugin": "^8.0.0",
@@ -33,6 +34,7 @@
     "globals": "^15.9.0",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.0",
-    "vite": "^5.4.2"
+    "vite": "^5.4.2",
+    "vitest": "^2.1.9"
   }
 }

--- a/apps/web/src/lib/api.test.ts
+++ b/apps/web/src/lib/api.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { api } from './api'
+
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+beforeEach(() => {
+  mockFetch.mockReset()
+})
+
+describe('api.listDomains', () => {
+  it('fetches domains from /api/v1/domains', async () => {
+    const payload = { domains: [{ domain_id: 'net', label: 'Network' }] }
+    mockFetch.mockResolvedValueOnce(jsonResponse(payload))
+
+    const result = await api.listDomains()
+
+    expect(mockFetch).toHaveBeenCalledOnce()
+    const url: string = mockFetch.mock.calls[0][0]
+    expect(url).toContain('/domains')
+    expect(result.domains).toHaveLength(1)
+    expect(result.domains[0].domain_id).toBe('net')
+  })
+})
+
+describe('api.getDomain', () => {
+  it('fetches a single domain by id', async () => {
+    const payload = { domain: { domain_id: 'net' }, nodes: [], edges: [], node_count: 0 }
+    mockFetch.mockResolvedValueOnce(jsonResponse(payload))
+
+    const result = await api.getDomain('net')
+
+    const url: string = mockFetch.mock.calls[0][0]
+    expect(url).toContain('/domains/net')
+    expect(result.domain.domain_id).toBe('net')
+  })
+})
+
+describe('api.getSubgraph', () => {
+  it('sends depth and relation_types as query params', async () => {
+    const payload = { center_node_id: 'vnet', nodes: [], edges: [] }
+    mockFetch.mockResolvedValueOnce(jsonResponse(payload))
+
+    await api.getSubgraph('vnet', 2, ['contains', 'depends_on'])
+
+    const url: string = mockFetch.mock.calls[0][0]
+    expect(url).toContain('/nodes/vnet/subgraph')
+    expect(url).toContain('depth=2')
+    expect(url).toContain('relation_types=contains')
+    expect(url).toContain('relation_types=depends_on')
+  })
+
+  it('defaults depth to 1 without relation_types', async () => {
+    const payload = { center_node_id: 'vnet', nodes: [], edges: [] }
+    mockFetch.mockResolvedValueOnce(jsonResponse(payload))
+
+    await api.getSubgraph('vnet')
+
+    const url: string = mockFetch.mock.calls[0][0]
+    expect(url).toContain('depth=1')
+    expect(url).not.toContain('relation_types')
+  })
+})
+
+describe('api.search', () => {
+  it('sends q, limit, and optional node_type', async () => {
+    const payload = { query: 'vnet', results: [], total: 0 }
+    mockFetch.mockResolvedValueOnce(jsonResponse(payload))
+
+    await api.search('vnet', 10, 'service')
+
+    const url: string = mockFetch.mock.calls[0][0]
+    expect(url).toContain('/search')
+    expect(url).toContain('q=vnet')
+    expect(url).toContain('limit=10')
+    expect(url).toContain('node_type=service')
+  })
+
+  it('omits node_type when not provided', async () => {
+    const payload = { query: 'subnet', results: [], total: 0 }
+    mockFetch.mockResolvedValueOnce(jsonResponse(payload))
+
+    await api.search('subnet')
+
+    const url: string = mockFetch.mock.calls[0][0]
+    expect(url).not.toContain('node_type')
+  })
+})
+
+describe('api.getEvidence', () => {
+  it('fetches evidence for a node', async () => {
+    const payload = { node_id: 'vnet', evidence: [{ evidence_id: 'e1' }] }
+    mockFetch.mockResolvedValueOnce(jsonResponse(payload))
+
+    const result = await api.getEvidence('vnet')
+
+    expect(result.node_id).toBe('vnet')
+    expect(result.evidence).toHaveLength(1)
+  })
+})
+
+describe('api.listJourneys', () => {
+  it('fetches journeys list', async () => {
+    const payload = { journeys: [{ journey_id: 'j1', title: 'Build VNet' }] }
+    mockFetch.mockResolvedValueOnce(jsonResponse(payload))
+
+    const result = await api.listJourneys()
+
+    expect(result.journeys).toHaveLength(1)
+  })
+})
+
+describe('api.getJourney', () => {
+  it('fetches a single journey by id', async () => {
+    const payload = { journey: { journey_id: 'j1' }, steps: [] }
+    mockFetch.mockResolvedValueOnce(jsonResponse(payload))
+
+    const result = await api.getJourney('j1')
+
+    const url: string = mockFetch.mock.calls[0][0]
+    expect(url).toContain('/journeys/j1')
+    expect(result.journey.journey_id).toBe('j1')
+  })
+})
+
+describe('error handling', () => {
+  it('throws on non-ok response', async () => {
+    mockFetch.mockResolvedValueOnce(new Response('Not Found', { status: 404 }))
+
+    await expect(api.getNode('nonexistent')).rejects.toThrow('API error 404')
+  })
+})

--- a/apps/web/src/pages/ConceptGraphPage.tsx
+++ b/apps/web/src/pages/ConceptGraphPage.tsx
@@ -5,9 +5,9 @@ import ReactFlowGraph from '../components/ReactFlowGraph'
 import { useDomain, useSubgraph } from '../hooks/useAtlas'
 
 const RELATION_TYPES = [
-  'contains', 'depends_on', 'communicates_with', 'authenticates',
-  'derives_from', 'implements', 'manages', 'monitors',
-  'optimizes', 'secures', 'connects_to', 'stores',
+  'belongs_to', 'contains', 'attached_to', 'depends_on',
+  'prerequisite_for', 'connects_to', 'routes_to', 'resolves_via',
+  'secures', 'monitors', 'alternative_to', 'related_to',
 ]
 
 const s: Record<string, React.CSSProperties> = {

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,3 +1,4 @@
+/// <reference types="vitest/config" />
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
@@ -11,5 +12,9 @@ export default defineConfig({
         changeOrigin: true,
       },
     },
+  },
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
   },
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       '@eslint/js':
         specifier: ^9.9.0
         version: 9.39.4
+      '@testing-library/jest-dom':
+        specifier: ^6.9.1
+        version: 6.9.1
       '@types/react':
         specifier: ^18.3.5
         version: 18.3.28
@@ -71,8 +74,14 @@ importers:
       vite:
         specifier: ^5.4.2
         version: 5.4.21
+      vitest:
+        specifier: ^2.1.9
+        version: 2.1.9
 
 packages:
+
+  '@adobe/css-tools@4.4.4':
+    resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -524,6 +533,10 @@ packages:
     peerDependencies:
       react: ^18 || ^19
 
+  '@testing-library/jest-dom@6.9.1':
+    resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
 
@@ -660,6 +673,35 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
+  '@vitest/expect@2.1.9':
+    resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
+
+  '@vitest/mocker@2.1.9':
+    resolution: {integrity: sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@2.1.9':
+    resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
+
+  '@vitest/runner@2.1.9':
+    resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
+
+  '@vitest/snapshot@2.1.9':
+    resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
+
+  '@vitest/spy@2.1.9':
+    resolution: {integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==}
+
+  '@vitest/utils@2.1.9':
+    resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
+
   '@xyflow/react@12.10.2':
     resolution: {integrity: sha512-CgIi6HwlcHXwlkTpr0fxLv/0sRVNZ8IdwKLzzeCscaYBwpvfcH1QFOCeaTCuEn1FQEs/B8CjnTSjhs8udgmBgQ==}
     peerDependencies:
@@ -689,6 +731,14 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  aria-query@5.3.2:
+    resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
+    engines: {node: '>= 0.4'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
@@ -716,6 +766,10 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
@@ -725,6 +779,10 @@ packages:
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -741,6 +799,10 @@ packages:
 
   character-reference-invalid@2.0.1:
     resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   classcat@5.0.5:
     resolution: {integrity: sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==}
@@ -764,6 +826,9 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
@@ -818,6 +883,10 @@ packages:
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
 
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
@@ -828,8 +897,14 @@ packages:
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
   electron-to-chromium@1.5.336:
     resolution: {integrity: sha512-AbH9q9J455r/nLmdNZes0G0ZKcRX73FicwowalLs6ijwOmCJSRRrLX63lcAlzy9ux3dWK1w1+1nsBJEWN11hcQ==}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
   esbuild@0.21.5:
     resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
@@ -900,9 +975,16 @@ packages:
   estree-util-is-identifier-name@3.0.0:
     resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
@@ -990,6 +1072,10 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
+
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
 
@@ -1067,8 +1153,14 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
   mdast-util-from-markdown@2.0.3:
     resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
@@ -1157,6 +1249,10 @@ packages:
   micromark@4.0.2:
     resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
+
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
@@ -1204,6 +1300,13 @@ packages:
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -1259,6 +1362,10 @@ packages:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
 
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
+
   remark-parse@11.0.0:
     resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
 
@@ -1294,6 +1401,9 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -1301,8 +1411,18 @@ packages:
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
+
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
 
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
@@ -1318,9 +1438,27 @@ packages:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@1.2.0:
+    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@3.0.2:
+    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
+    engines: {node: '>=14.0.0'}
 
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
@@ -1388,6 +1526,11 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
+  vite-node@2.1.9:
+    resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
   vite@5.4.21:
     resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -1419,9 +1562,39 @@ packages:
       terser:
         optional: true
 
+  vitest@2.1.9:
+    resolution: {integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 2.1.9
+      '@vitest/ui': 2.1.9
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -1454,6 +1627,8 @@ packages:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
+
+  '@adobe/css-tools@4.4.4': {}
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -1804,6 +1979,15 @@ snapshots:
       '@tanstack/query-core': 5.99.0
       react: 18.3.1
 
+  '@testing-library/jest-dom@6.9.1':
+    dependencies:
+      '@adobe/css-tools': 4.4.4
+      aria-query: 5.3.2
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
   '@types/babel__core@7.20.5':
     dependencies:
       '@babel/parser': 7.29.2
@@ -1988,6 +2172,46 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitest/expect@2.1.9':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      tinyrainbow: 1.2.0
+
+  '@vitest/mocker@2.1.9(vite@5.4.21)':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 5.4.21
+
+  '@vitest/pretty-format@2.1.9':
+    dependencies:
+      tinyrainbow: 1.2.0
+
+  '@vitest/runner@2.1.9':
+    dependencies:
+      '@vitest/utils': 2.1.9
+      pathe: 1.1.2
+
+  '@vitest/snapshot@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      magic-string: 0.30.21
+      pathe: 1.1.2
+
+  '@vitest/spy@2.1.9':
+    dependencies:
+      tinyspy: 3.0.2
+
+  '@vitest/utils@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      loupe: 3.2.1
+      tinyrainbow: 1.2.0
+
   '@xyflow/react@12.10.2(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@xyflow/system': 0.0.76
@@ -2030,6 +2254,10 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  aria-query@5.3.2: {}
+
+  assertion-error@2.0.1: {}
+
   bail@2.0.2: {}
 
   balanced-match@1.0.2: {}
@@ -2055,11 +2283,21 @@ snapshots:
       node-releases: 2.0.37
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
+  cac@6.7.14: {}
+
   callsites@3.1.0: {}
 
   caniuse-lite@1.0.30001787: {}
 
   ccount@2.0.1: {}
+
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
 
   chalk@4.1.2:
     dependencies:
@@ -2073,6 +2311,8 @@ snapshots:
   character-entities@2.0.2: {}
 
   character-reference-invalid@2.0.1: {}
+
+  check-error@2.1.3: {}
 
   classcat@5.0.5: {}
 
@@ -2093,6 +2333,8 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  css.escape@1.5.1: {}
 
   csstype@3.2.3: {}
 
@@ -2140,6 +2382,8 @@ snapshots:
     dependencies:
       character-entities: 2.0.2
 
+  deep-eql@5.0.2: {}
+
   deep-is@0.1.4: {}
 
   dequal@2.0.3: {}
@@ -2148,7 +2392,11 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
+  dom-accessibility-api@0.6.3: {}
+
   electron-to-chromium@1.5.336: {}
+
+  es-module-lexer@1.7.0: {}
 
   esbuild@0.21.5:
     optionalDependencies:
@@ -2256,7 +2504,13 @@ snapshots:
 
   estree-util-is-identifier-name@3.0.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   esutils@2.0.3: {}
+
+  expect-type@1.3.0: {}
 
   extend@3.0.2: {}
 
@@ -2338,6 +2592,8 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
+  indent-string@4.0.0: {}
+
   inline-style-parser@0.2.7: {}
 
   is-alphabetical@2.0.1: {}
@@ -2398,9 +2654,15 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
+  loupe@3.2.1: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   mdast-util-from-markdown@2.0.3:
     dependencies:
@@ -2624,6 +2886,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  min-indent@1.0.1: {}
+
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.5
@@ -2674,6 +2938,10 @@ snapshots:
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
+
+  pathe@1.1.2: {}
+
+  pathval@2.0.1: {}
 
   picocolors@1.1.1: {}
 
@@ -2732,6 +3000,11 @@ snapshots:
   react@18.3.1:
     dependencies:
       loose-envify: 1.4.0
+
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
 
   remark-parse@11.0.0:
     dependencies:
@@ -2797,14 +3070,24 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  siginfo@2.0.0: {}
+
   source-map-js@1.2.1: {}
 
   space-separated-tokens@2.0.2: {}
+
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
 
   stringify-entities@4.0.4:
     dependencies:
       character-entities-html4: 2.1.0
       character-entities-legacy: 3.0.0
+
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
 
   strip-json-comments@3.1.1: {}
 
@@ -2820,10 +3103,20 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
   tinyglobby@0.2.16:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@1.2.0: {}
+
+  tinyspy@3.0.2: {}
 
   trim-lines@3.0.1: {}
 
@@ -2907,6 +3200,24 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
+  vite-node@2.1.9:
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 1.1.2
+      vite: 5.4.21
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   vite@5.4.21:
     dependencies:
       esbuild: 0.21.5
@@ -2915,9 +3226,47 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
+  vitest@2.1.9:
+    dependencies:
+      '@vitest/expect': 2.1.9
+      '@vitest/mocker': 2.1.9(vite@5.4.21)
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.9
+      '@vitest/snapshot': 2.1.9
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.1.1
+      tinyrainbow: 1.2.0
+      vite: 5.4.21
+      vite-node: 2.1.9
+      why-is-node-running: 2.3.0
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 


### PR DESCRIPTION
## Summary

Fixes all 6 issues identified during code review (#30–#35).

## Changes

### Bug Fixes
- **#30** — Align `RELATION_TYPES` filter in `ConceptGraphPage.tsx` with actual DB `relation_type_enum` values (removed `communicates_with`, `authenticates`, `derives_from` etc. that don't exist)
- **#31** — Remove `--schema-only` flag from `entrypoint.sh` so seed data loads on production boot (was producing an empty DB)
- **#32** — Add `tgt.domain_id = $1` filter in `domains.py` edge query to prevent cross-domain edges leaking into domain views

### Enhancements
- **#33** — Add `curation_decisions` audit table (`002_curation_audit.sql`) and persist curation decisions in `curation.py` for audit trail
- **#34** — Update README: `Cytoscape.js` → `React Flow (@xyflow/react)`, mark ARQ worker as stub, fix CI badge URL
- **#35** — Set up vitest with 10 unit tests for the API client (`api.test.ts`); add `--strict` flag to `migrate.py` that fails on checksum mismatch instead of warning

## Testing

- `pnpm test` — 10/10 frontend tests pass ✅
- `pytest tests/` — 22/22 API tests pass ✅
- `tsc --noEmit` — clean ✅

Closes #30, closes #31, closes #32, closes #33, closes #34, closes #35