### PR TITLE
improve(web): reduce graph visual clutter for better readability

### DIFF
--- a/apps/web/src/components/ReactFlowGraph.tsx
+++ b/apps/web/src/components/ReactFlowGraph.tsx
@@ -61,8 +61,8 @@ const NODE_COLORS: Record<string, string> = {
 	default: "#64748b",
 };
 
-const NODE_WIDTH = 220;
-const NODE_HEIGHT = 92;
+const NODE_WIDTH = 240;
+const NODE_HEIGHT = 116;
 
 type FlowCssVars = CSSProperties & Record<`--${string}`, string>;
 
@@ -279,10 +279,10 @@ function getLayoutedNodes(
 	const graph = new dagre.graphlib.Graph();
 	graph.setGraph({
 		rankdir: nodes.length > 10 ? "LR" : "TB",
-		nodesep: 42,
-		ranksep: 110,
-		marginx: 32,
-		marginy: 32,
+		nodesep: 72,
+		ranksep: 160,
+		marginx: 48,
+		marginy: 48,
 	});
 	graph.setDefaultEdgeLabel(() => ({}));
 
@@ -420,8 +420,8 @@ export default function ReactFlowGraph({
 				id: edge.edge_id,
 				source: edge.source_id,
 				target: edge.target_id,
-				animated: true,
-				label: edge.relation_type,
+				animated: isSelected,
+				label: isSelected ? edge.relation_type : undefined,
 				markerEnd: {
 					type: MarkerType.ArrowClosed,
 					width: 18,
@@ -432,28 +432,28 @@ export default function ReactFlowGraph({
 					stroke: isSelected
 						? "var(--graph-edge-selected)"
 						: "var(--graph-edge-color)",
-					strokeWidth: isSelected ? 2.5 : 1.6,
-					opacity: isDimmed ? 0.2 : 1,
+					strokeWidth: isSelected ? 2.5 : 1.4,
+					opacity: isDimmed ? 0.15 : 0.9,
 				},
-				labelStyle: {
-					fill: isSelected
-						? "var(--graph-edge-label-selected-text)"
-						: "var(--graph-edge-label-text)",
-					fontSize: 11,
-					fontWeight: 600,
-				},
-				labelBgStyle: {
-					fill: "var(--graph-edge-label-bg)",
-					stroke: isSelected
-						? "var(--graph-edge-selected)"
-						: "var(--graph-edge-color)",
-					strokeWidth: 1,
-					fillOpacity: isSelected ? 0.94 : 0.86,
-					rx: 6,
-					ry: 6,
-				},
-				labelBgPadding: [6, 3],
-				labelBgBorderRadius: 6,
+				...(isSelected
+					? {
+							labelStyle: {
+								fill: "var(--graph-edge-label-selected-text)",
+								fontSize: 11,
+								fontWeight: 600,
+							},
+							labelBgStyle: {
+								fill: "var(--graph-edge-label-bg)",
+								stroke: "var(--graph-edge-selected)",
+								strokeWidth: 1,
+								fillOpacity: 0.94,
+								rx: 6,
+								ry: 6,
+							},
+							labelBgPadding: [6, 3] as [number, number],
+							labelBgBorderRadius: 6,
+						}
+					: {}),
 			};
 		});
 	}, [colorMode, edges, selectedNodeId]);


### PR DESCRIPTION
## Summary
- Increase dagre layout spacing to prevent node overlap in dense domains (Network: 43 nodes)
- Enlarge node cards (220×92 → 240×116) to accommodate longer Azure concept names
- Show edge labels and animation only on selected edges ("simple by default, detail on select")
- Reduce visual noise with lower base opacity and thinner unselected edges

## Changes
| Parameter | Before | After |
|-----------|--------|-------|
| `nodesep` | 42 | 72 |
| `ranksep` | 110 | 160 |
| `margin` | 32 | 48 |
| `NODE_WIDTH` | 220 | 240 |
| `NODE_HEIGHT` | 92 | 116 |
| Edge labels | Always shown | Selected edges only |
| Animation | All edges | Selected edges only |
| Dimmed opacity | 0.2 | 0.15 |
| Base opacity | 1.0 | 0.9 |
| Stroke width (unselected) | 1.6 | 1.4 |

## Rationale
Azure Atlas is a knowledge map, not a diagram tool. Showing all edge labels and animations simultaneously creates information overload rather than aiding exploration. The "simple by default, detail on select" pattern better serves the exploration use case.