### PR TITLE
fix(web): default to light theme instead of system preference

### DIFF
--- a/apps/web/src/components/ReactFlowGraph.tsx
+++ b/apps/web/src/components/ReactFlowGraph.tsx
@@ -339,7 +339,7 @@ export default function ReactFlowGraph({
 	const [tooltip, setTooltip] = useState<TooltipState | null>(null);
 	const [colorMode, setColorMode] = useState<"light" | "dark">(() => {
 		if (typeof document === "undefined") {
-			return "dark";
+			return "light";
 		}
 
 		return document.documentElement.getAttribute("data-theme") === "light"

--- a/apps/web/src/hooks/useTheme.ts
+++ b/apps/web/src/hooks/useTheme.ts
@@ -4,16 +4,11 @@ type Theme = 'light' | 'dark'
 
 const STORAGE_KEY = 'azure-atlas-theme'
 
-function getSystemTheme(): Theme {
-  if (typeof window === 'undefined') return 'dark'
-  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
-}
-
 function getInitialTheme(): Theme {
-  if (typeof window === 'undefined') return 'dark'
+  if (typeof window === 'undefined') return 'light'
   const stored = localStorage.getItem(STORAGE_KEY)
   if (stored === 'light' || stored === 'dark') return stored
-  return getSystemTheme()
+  return 'light'
 }
 
 export function useTheme() {

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -21,7 +21,7 @@ const queryClient = new QueryClient({
   const stored = localStorage.getItem('azure-atlas-theme')
   const theme = stored === 'light' || stored === 'dark'
     ? stored
-    : window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+    : 'light'
   document.documentElement.setAttribute('data-theme', theme)
 })()
 


### PR DESCRIPTION
## Summary

- Default theme changed from system preference to **light** when no localStorage value exists
- Removed `getSystemTheme()` helper from `useTheme.ts` — no longer needed
- Updated SSR fallback in `ReactFlowGraph.tsx` from `"dark"` to `"light"`
- Updated `main.tsx` pre-render init to use `'light'` fallback instead of `matchMedia`

## Why

User requested light theme as the default experience. Previously, first-time visitors with dark system preference would see dark mode, which was not the desired default.

## Changes

| File | Change |
|------|--------|
| `apps/web/src/hooks/useTheme.ts` | Remove `getSystemTheme()`, fallback to `'light'` |
| `apps/web/src/main.tsx` | initTheme IIFE fallback `'light'` instead of `matchMedia` |
| `apps/web/src/components/ReactFlowGraph.tsx` | SSR colorMode fallback `"light"` |